### PR TITLE
Add 'list' argument to mcp-client to list the available tool

### DIFF
--- a/cmd/mcp-client/main.go
+++ b/cmd/mcp-client/main.go
@@ -30,9 +30,10 @@ import (
 
 func main() {
 	serverURL := flag.String("url", "", "MCP server URL (e.g. http://localhost:8080/)")
-	toolName := flag.String("tool", "get_mesh_info", "Tool to call")
+	toolName := flag.String("tool", "", "Tool to call")
 	toolArgs := flag.String("args", "{}", "JSON arguments for the tool")
-	timoutArgs := flag.Int("timeout", 10, "Timeout in seconds")
+	timeoutArgs := flag.Int("timeout", 10, "Timeout in seconds")
+	listTools := flag.Bool("list", false, "List available tools and exit")
 	flag.Parse()
 
 	if *serverURL == "" {
@@ -41,8 +42,8 @@ func main() {
 
 	var ctx context.Context
 	var cancel context.CancelFunc
-	if timoutArgs != nil {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(*timoutArgs)*time.Second)
+	if timeoutArgs != nil {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(*timeoutArgs)*time.Second)
 	} else {
 		ctx = context.Background()
 	}
@@ -72,6 +73,17 @@ func main() {
 			log.Printf("Failed to close session: %v", err)
 		}
 	}()
+
+	if *listTools || *toolName == "" {
+		tools, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+		if err != nil {
+			log.Fatalf("ListTools failed: %v", err)
+		}
+		for _, t := range tools.Tools {
+			fmt.Printf("%s\t%s\n", t.Name, t.Description)
+		}
+		return
+	}
 
 	var args map[string]any
 	if *toolArgs != "" {

--- a/cmd/mcp-client/main.go
+++ b/cmd/mcp-client/main.go
@@ -40,13 +40,7 @@ func main() {
 		log.Fatal("Must specify -url")
 	}
 
-	var ctx context.Context
-	var cancel context.CancelFunc
-	if timeoutArgs != nil {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(*timeoutArgs)*time.Second)
-	} else {
-		ctx = context.Background()
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*timeoutArgs)*time.Second)
 	defer cancel()
 
 	sigs := make(chan os.Signal, 1)

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -121,7 +121,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
   mesh_get_node_count_via_mcp() {
     local idx="$1"
     local output
-    output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+    output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
     echo "${output}" | jq '.known_peers | length'
   }
 
@@ -132,7 +132,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "Node ${idx} get_mesh_info raw output: ${output}"
       local count
       count="$(echo "${output}" | jq '.known_peers | length')"
@@ -152,7 +152,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "[$(date +%T)] Node ${idx} get_mesh_info raw output: ${output}"
       local connected
       connected="$(echo "${output}" | jq -r --arg peer "$target_peer" '.connected_peers | index($peer) != null')"
@@ -172,7 +172,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "[$(date +%T)] Node ${idx} get_mesh_info raw output: ${output}"
       local connected
       connected="$(echo "${output}" | jq -r --arg peer "$target_peer" '.connected_peers | index($peer) != null')"

--- a/tests/e2e/policy.bats
+++ b/tests/e2e/policy.bats
@@ -239,7 +239,7 @@ EOF"
   
   for ((i=0; i<30; i++)); do
     local output
-    output="$(docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-2:8080/mcp/events" 2>/dev/null)"
+    output="$(docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-2:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
     TARGET_PEER_ID=$(echo "${output}" | grep -oE '12D3Koo[a-zA-Z0-9]+' | grep -v "${hub_id}" | grep -v "${node2_id}" | head -n 1)
     if [[ -n "${TARGET_PEER_ID}" ]]; then
       break


### PR DESCRIPTION
Listing available tools is a first-class feature of the MCP protocol. This PR adds a `-list` flag to `mcp-client` and makes it the default behavior