### PR TITLE
[WIP] feat: add agent-to-agent direct messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ go.work.sum
 # env file
 .env
 
+# Local hub policy (copy from policies.example.yaml)
+policies.yaml
+
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/cmd/sam-hub/main.go
+++ b/cmd/sam-hub/main.go
@@ -418,6 +418,10 @@ func (h *Hub) mintBiscuitToken(claims jwt.MapClaims, token *oidc.IDToken, remote
 			}
 		}
 	}
+	// JWTs without a "roles" claim get the "default" role.
+	if len(roles) == 0 {
+		roles = []string{"default"}
+	}
 
 	builder := biscuit.NewBuilder(h.KeyRing.GetCurrentKey())
 

--- a/cmd/sam-node/gate.go
+++ b/cmd/sam-node/gate.go
@@ -87,11 +87,25 @@ func (n *SamNode) HandleMCPStream(s network.Stream) {
 		Version: "0.1.0",
 	}, nil)
 
-	// Add the send_message tool.
+	// Sender identity is taken from the authenticated libp2p peer, not from
+	// caller-supplied arguments — it cannot be spoofed.
+	senderPeer := s.Conn().RemotePeer()
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "send_message",
-		Description: "Send a message to another agent in the mesh",
-	}, handleSendMessage)
+		Name:        "put_message",
+		Description: "Place a message in this node's inbox",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params struct {
+		Message string `json:"message" jsonschema:"The message content"`
+	}) (*mcp.CallToolResult, any, error) {
+		n.mu.Lock()
+		key := senderPeer.String()
+		n.receivedDirectMsgs[key] = append(n.receivedDirectMsgs[key], params.Message)
+		n.mu.Unlock()
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "stored"},
+			},
+		}, nil, nil
+	})
 
 	// Add the get_mesh_info tool.
 	mcp.AddTool(server, &mcp.Tool{
@@ -171,12 +185,7 @@ func (t *StreamTransport) Read(ctx context.Context) (jsonrpc.Message, error) {
 		return nil, err
 	}
 	defer t.r.ReleaseMsg(msg)
-
-	var jsonRpcMsg jsonrpc.Message
-	if err := json.Unmarshal(msg, &jsonRpcMsg); err != nil {
-		return nil, err
-	}
-	return jsonRpcMsg, nil
+	return jsonrpc.DecodeMessage(msg)
 }
 
 // Close closes the stream.
@@ -198,7 +207,7 @@ func (t *StreamTransport) SessionID() string {
 
 // Write writes a message to the stream.
 func (t *StreamTransport) Write(ctx context.Context, msg jsonrpc.Message) error {
-	data, err := json.Marshal(msg)
+	data, err := jsonrpc.EncodeMessage(msg)
 	if err != nil {
 		return err
 	}

--- a/cmd/sam-node/mcp.go
+++ b/cmd/sam-node/mcp.go
@@ -29,23 +29,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// SendMessageParams defines the parameters for the send_message tool.
-type SendMessageParams struct {
-	PeerID  string `json:"peer_id" jsonschema:"The Peer ID of the target agent"`
-	Message string `json:"message" jsonschema:"The message content"`
-}
-
-// handleSendMessage implements the send_message tool.
-func handleSendMessage(ctx context.Context, req *mcp.CallToolRequest, params SendMessageParams) (*mcp.CallToolResult, any, error) {
-	response := fmt.Sprintf("Simulated sending message to %s: %s", params.PeerID, params.Message)
-
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: response},
-		},
-	}, nil, nil
-}
-
 // NewMCPHandler creates a new HTTP handler for the MCP server using the official SDK.
 func NewMCPHandler(node *SamNode) http.Handler {
 	// Create an MCP server.
@@ -54,11 +37,63 @@ func NewMCPHandler(node *SamNode) http.Handler {
 		Version: "0.1.0",
 	}, nil)
 
-	// Add the send_message tool.
+	// send_message dispatches to the target's put_message tool over libp2p MCP.
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name:        "send_message",
 		Description: "Send a message to another agent in the mesh",
-	}, handleSendMessage)
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params struct {
+		PeerID  string `json:"peer_id" jsonschema:"The Peer ID of the target agent"`
+		Message string `json:"message" jsonschema:"The message content"`
+	}) (*mcp.CallToolResult, any, error) {
+		targetPeer, err := peer.Decode(params.PeerID)
+		if err != nil {
+			return nil, nil, err
+		}
+		res, err := node.CallMCPTool(ctx, targetPeer, "put_message", map[string]any{
+			"message": params.Message,
+		})
+		return res, nil, err
+	})
+
+	// Add the poll_direct_messages tool. Drains the inbox of messages received
+	// from other agents and returns them as a flat JSON list of {from, message}.
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name:        "poll_direct_messages",
+		Description: "Poll for direct messages from other agents (drains the inbox)",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, params struct {
+		PeerID string `json:"peer_id,omitempty" jsonschema:"Optional sender peer ID filter; if empty returns all"`
+	}) (*mcp.CallToolResult, any, error) {
+		type entry struct {
+			From    string `json:"from"`
+			Message string `json:"message"`
+		}
+		var out []entry
+		node.mu.Lock()
+		if params.PeerID != "" {
+			for _, m := range node.receivedDirectMsgs[params.PeerID] {
+				out = append(out, entry{From: params.PeerID, Message: m})
+			}
+			delete(node.receivedDirectMsgs, params.PeerID)
+		} else {
+			for from, msgs := range node.receivedDirectMsgs {
+				for _, m := range msgs {
+					out = append(out, entry{From: from, Message: m})
+				}
+			}
+			node.receivedDirectMsgs = make(map[string][]string)
+		}
+		node.mu.Unlock()
+
+		data, err := json.Marshal(out)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: string(data)},
+			},
+		}, nil, nil
+	})
 
 	// Add list_local_services tool
 	mcp.AddTool(mcpServer, &mcp.Tool{
@@ -360,13 +395,9 @@ func (n *SamNode) callMCPToolOnce(ctx context.Context, targetPeer peer.ID, toolN
 	}
 
 	callParams := &mcp.CallToolParams{
-		Name: toolName,
+		Name:      toolName,
+		Arguments: params,
 	}
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal params for tool %s: %w", toolName, err)
-	}
-	callParams.Arguments = paramsBytes // Assume it takes bytes or raw message!
 
 	res, err := session.CallTool(ctx, callParams)
 	if err != nil {

--- a/cmd/sam-node/node.go
+++ b/cmd/sam-node/node.go
@@ -88,9 +88,10 @@ type SamNode struct {
 	PubSub            *pubsub.PubSub
 	Store             *Store
 	HubPeerID         peer.ID
-	knownPeers        map[string]bool
-	receivedMsgs      map[string][]string
-	topics            map[string]*pubsub.Topic
+	knownPeers         map[string]bool
+	receivedMsgs       map[string][]string
+	receivedDirectMsgs map[string][]string
+	topics             map[string]*pubsub.Topic
 	mu                sync.Mutex
 	LocalPolicy       *NodeConfigComplete
 	revokedPeers      *lru.Cache[string, int64]
@@ -111,13 +112,14 @@ func NewSamNode(ctx context.Context, privKey crypto.PrivKey, hubPubKey ed25519.P
 	}
 
 	node := &SamNode{
-		Store:        store,
-		trustedKeys:  trustedKeys,
-		knownPeers:   make(map[string]bool),
-		receivedMsgs: make(map[string][]string),
-		topics:       make(map[string]*pubsub.Topic),
-		services:     make(map[string]*ServiceManifest),
-		LocalPolicy:  nodeConfig,
+		Store:              store,
+		trustedKeys:        trustedKeys,
+		knownPeers:         make(map[string]bool),
+		receivedMsgs:       make(map[string][]string),
+		receivedDirectMsgs: make(map[string][]string),
+		topics:             make(map[string]*pubsub.Topic),
+		services:           make(map[string]*ServiceManifest),
+		LocalPolicy:        nodeConfig,
 	}
 
 	var err error

--- a/policies.example.yaml
+++ b/policies.example.yaml
@@ -1,0 +1,13 @@
+version: "1"
+
+# Hub adds these facts to a peer's biscuit. JWTs without a "roles" claim
+# get the "default" role.
+roles:
+  default:
+    mcp:
+      # libp2p protocol IDs the peer is allowed to use.
+      allowed_tools:
+        - "/sam/mcp/1.0.0"
+    network:
+      # Hosts the egress proxy will let the peer reach.
+      allowed_targets: []


### PR DESCRIPTION
This PR adds agent-to-agent direct communication. The implementation has been validated manually, both using the `mcp-client` binary and commercial agents (Claude desktop and Github copilot).

Still missing:
* Proper testing
* Docs
