### PR TITLE
Use http for OIDC enrollment to improve UX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ docker-build-hub:
 	docker build -t sam-hub:local -f Dockerfile.sam-hub .
 
 docker-build-node:
-	docker build -t sam-node:local -f Dockerfile.sam-node .
+	docker build --no-cache -t sam-node:local -f Dockerfile.sam-node .
 
 docker-build-mock-oidc:
 	docker build -t sam-mock-oidc:local -f tests/e2e/docker/Dockerfile.mock-oidc .

--- a/cmd/sam-hub/hooks.go
+++ b/cmd/sam-hub/hooks.go
@@ -34,13 +34,11 @@ var _ connmgr.ConnectionGater = (*hubConnGate)(nil)
 type hubConnGate struct {
 	mu            sync.RWMutex
 	authenticated map[peer.ID]bool
-	pending       map[peer.ID]time.Time
 }
 
 func newHubConnGate() *hubConnGate {
 	return &hubConnGate{
 		authenticated: make(map[peer.ID]bool),
-		pending:       make(map[peer.ID]time.Time),
 	}
 }
 
@@ -50,11 +48,6 @@ func (g *hubConnGate) InterceptAddrDial(p peer.ID, m multiaddr.Multiaddr) bool {
 func (g *hubConnGate) InterceptAccept(c network.ConnMultiaddrs) bool           { return true }
 
 func (g *hubConnGate) InterceptSecured(dir network.Direction, p peer.ID, mas network.ConnMultiaddrs) bool {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if !g.authenticated[p] {
-		g.pending[p] = time.Now()
-	}
 	return true
 }
 
@@ -78,7 +71,6 @@ func (n *notifier) Disconnected(_ network.Network, c network.Conn) {
 	n.hub.gater.mu.Lock()
 	wasAuth := n.hub.gater.authenticated[p]
 	delete(n.hub.gater.authenticated, p)
-	delete(n.hub.gater.pending, p)
 	n.hub.gater.mu.Unlock()
 	
 	logger.Infow("Peer disconnected", "peer_id", p, "was_authenticated", wasAuth)

--- a/cmd/sam-hub/keyring.go
+++ b/cmd/sam-hub/keyring.go
@@ -192,6 +192,18 @@ func (kr *KeyRing) GetAllValidKeys() []ed25519.PrivateKey {
 	return keys
 }
 
+// GetAllValidPublicKeys returns all public keys that are still valid.
+func (kr *KeyRing) GetAllValidPublicKeys() []ed25519.PublicKey {
+	kr.mu.RLock()
+	defer kr.mu.RUnlock()
+
+	keys := []ed25519.PublicKey{ed25519.PublicKey(kr.Current.Public)}
+	for _, kp := range kr.Previous {
+		keys = append(keys, ed25519.PublicKey(kp.Public))
+	}
+	return keys
+}
+
 // Close closes the BoltDB database.
 func (kr *KeyRing) Close() error {
 	return kr.db.Close()

--- a/cmd/sam-hub/main.go
+++ b/cmd/sam-hub/main.go
@@ -135,8 +135,9 @@ func NewHub(ctx context.Context, policy *api.PolicyConfig) (*Hub, error) {
 		libp2p.Security(libp2ptls.ID, libp2ptls.New),
 		libp2p.EnableRelayService(),
 		libp2p.ConnectionGater(gater),
-		libp2p.EnableNATService(),
 		libp2p.ConnectionManager(cm),
+		libp2p.EnableAutoNATv2(),
+		libp2p.EnableNATService(),
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/sam-hub/main.go
+++ b/cmd/sam-hub/main.go
@@ -168,7 +168,10 @@ func NewHub(ctx context.Context, policy *api.PolicyConfig) (*Hub, error) {
 			tr := &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
-			client := &http.Client{Transport: tr}
+			client := &http.Client{
+				Timeout:   30 * time.Second,
+				Transport: tr,
+			}
 			providerCtx = oidc.ClientContext(ctx, client)
 		}
 		provider, err := oidc.NewProvider(providerCtx, iss)
@@ -269,7 +272,7 @@ func (h *Hub) handleAuthHandshake(s network.Stream) {
 	}
 
 	logger.Infof("[AuthN] Successfully authenticated peer %s", remotePeer)
-	
+
 	// Update active nodes gauge and gater state
 	h.gater.mu.Lock()
 	if !h.gater.authenticated[remotePeer] {
@@ -299,7 +302,7 @@ func (h *Hub) handleAuthHandshake(s network.Stream) {
 			}
 		}
 	}
-	
+
 	// Send ACK back to client
 	writer := msgio.NewVarintWriter(s)
 	resp := &api.AuthResponse{Success: true}
@@ -507,7 +510,6 @@ func (h *Hub) mintBiscuitToken(claims jwt.MapClaims, token *oidc.IDToken, remote
 // startWatchdog periodically checks for peers that have connected but not completed OIDC
 // authentication within the grace period, and evicts them from the network.
 
-
 func (h *Hub) startRotation(ctx context.Context) {
 	if keyRotationInterval <= 0 {
 		return
@@ -621,8 +623,6 @@ func main() {
 			// Start key rotation if enabled
 			h.startRotation(ctx)
 
-
-
 			startHTTPServer(h, bindAddress, adminToken, tlsCertFile, tlsKeyFile, tlsCAFile, &isHubReady)
 
 			logger.Infof("SAM Hub Online (QUIC + TCP)")
@@ -700,6 +700,7 @@ func main() {
 			}
 
 			client := &http.Client{
+				Timeout: 30 * time.Second,
 				Transport: &http.Transport{
 					TLSClientConfig: tlsConfig,
 				},

--- a/cmd/sam-hub/main.go
+++ b/cmd/sam-hub/main.go
@@ -230,89 +230,53 @@ func NewHub(ctx context.Context, policy *api.PolicyConfig) (*Hub, error) {
 	return hub, nil
 }
 
-func (h *Hub) handleEnroll(s network.Stream) {
+func (h *Hub) handleAuthHandshake(s network.Stream) {
 	defer func() {
-		_ = s.Close()
+		if err := s.Close(); err != nil {
+			logger.Errorf("[AuthN] Failed to close auth stream: %v", err)
+		}
 	}()
 	remotePeer := s.Conn().RemotePeer()
-
-	if !h.limiter.Allow() {
-		logger.Warnw("Rate limit exceeded during enrollment", "peer_id", remotePeer)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		_ = s.Reset()
-		return
-	}
-
-	logger.Infow("New enrollment request", "peer_id", remotePeer)
 
 	reader := msgio.NewVarintReaderSize(s, 1024*64)
 	msg, err := reader.ReadMsg()
 	if err != nil {
-		logger.Errorw("Failed to read enrollment message", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
+		logger.Errorf("[AuthN] Failed to read handshake from %s: %v", remotePeer, err)
 		return
 	}
 	defer reader.ReleaseMsg(msg)
 
-	var req api.EnrollRequest
-	if err := proto.Unmarshal(msg, &req); err != nil {
-		logger.Errorw("Failed to unmarshal enrollment request", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
+	var exchange api.AuthFrame
+	if err := proto.Unmarshal(msg, &exchange); err != nil {
+		logger.Warnf("[AuthN] Invalid protobuf from %s", remotePeer)
 		return
 	}
 
-	if req.PeerId != remotePeer.String() {
-		logger.Warnw("Peer ID mismatch in enrollment", "peer_id", remotePeer, "requested_peer_id", req.PeerId)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		h.sendEnrollResponse(s, nil, "Peer ID mismatch", 0, nil, nil)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), JWTVerificationTimeout)
-	defer cancel()
-	claims, token, err := h.parseAndVerifyJWT(ctx, req.Jwt, h.AllowedAudiences)
+	b, err := h.verifyBiscuit(exchange.Biscuit, remotePeer)
 	if err != nil {
-		logger.Errorw("JWT verification failed", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		h.sendEnrollResponse(s, nil, err.Error(), 0, nil, nil)
+		logger.Warnf("[AuthN] Authorization failed for %s: %v", remotePeer, err)
 		return
 	}
 
-	biscuitData, err := h.mintBiscuitToken(claims, token, remotePeer)
-	if err != nil {
-		logger.Errorw("Biscuit minting failed", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		h.sendEnrollResponse(s, nil, "Failed to mint biscuit", 0, nil, nil)
+	// Enforce hardware binding: token must include node(<remotePeerID>)
+	boundFact := biscuit.Fact{Predicate: biscuit.Predicate{
+		Name: "node",
+		IDs:  []biscuit.Term{biscuit.String(remotePeer.String())},
+	}}
+	if _, err := b.GetBlockID(boundFact); err != nil {
+		logger.Warnf("[AuthN] Token is not bound to peer %s", remotePeer)
 		return
 	}
 
+	logger.Infof("[AuthN] Successfully authenticated peer %s", remotePeer)
+	
+	// Update active nodes gauge and gater state
 	h.gater.mu.Lock()
-	// Update active nodes gauge if this is a new node
 	if !h.gater.authenticated[remotePeer] {
 		samHubActiveNodes.Inc()
 	}
 	h.gater.authenticated[remotePeer] = true
-	delete(h.gater.pending, remotePeer)
-
-	// Collect authenticated peers
-	var authPeers []peer.ID
-	for p := range h.gater.authenticated {
-		authPeers = append(authPeers, p)
-	}
 	h.gater.mu.Unlock()
-
-	var knownPeers []string
-	for _, p := range authPeers {
-		knownPeers = append(knownPeers, p.String())
-	}
-
-	policies := []string{
-		`allow if operation($op)`,
-	}
-
-	h.sendEnrollResponse(s, biscuitData, "", token.Expiry.Unix(), knownPeers, policies)
-	logger.Infow("Successfully enrolled peer", "peer_id", remotePeer)
-	samHubEnrollmentTotal.WithLabelValues("success").Inc()
 
 	// Publish JOIN event
 	event := &api.MeshEvent{
@@ -335,43 +299,46 @@ func (h *Hub) handleEnroll(s network.Stream) {
 			}
 		}
 	}
+	
+	// Send ACK back to client
+	writer := msgio.NewVarintWriter(s)
+	resp := &api.AuthResponse{Success: true}
+	respBytes, _ := proto.Marshal(resp)
+	if err := writer.WriteMsg(respBytes); err != nil {
+		logger.Errorf("[AuthN] Failed to write ACK to %s: %v", remotePeer, err)
+	}
 }
 
-func (h *Hub) sendEnrollResponse(s network.Stream, biscuitToken []byte, errMsg string, expiration int64, knownPeers []string, policies []string) {
-	var hubAddrs []string
-	if len(h.ExternalAddrs) > 0 {
-		for _, addr := range h.ExternalAddrs {
-			fullAddr := addr
-			if !strings.Contains(addr, "/p2p/") {
-				fullAddr = addr + "/p2p/" + h.Host.ID().String()
-			}
-			hubAddrs = append(hubAddrs, fullAddr)
-		}
-	} else {
-		for _, addr := range h.Host.Addrs() {
-			hubAddrs = append(hubAddrs, addr.String()+"/p2p/"+h.Host.ID().String())
-		}
-	}
-
-	pubKey := h.KeyRing.GetCurrentPublicKey()
-
-	resp := &api.EnrollResponse{
-		BiscuitToken: biscuitToken,
-		ErrorMessage: errMsg,
-		HubPublicKey: pubKey,
-		HubAddresses: hubAddrs,
-		Expiration:   expiration,
-		KnownPeers:   knownPeers,
-	}
-	data, err := proto.Marshal(resp)
+func (h *Hub) verifyBiscuit(biscuitData []byte, remotePeer peer.ID) (*biscuit.Biscuit, error) {
+	b, err := biscuit.Unmarshal(biscuitData)
 	if err != nil {
-		logger.Errorf("[Enroll] Failed to marshal response: %v", err)
-		return
+		return nil, fmt.Errorf("malformed biscuit: %w", err)
 	}
-	writer := msgio.NewVarintWriter(s)
-	if err := writer.WriteMsg(data); err != nil {
-		logger.Errorf("[Enroll] Failed to write response: %v", err)
+
+	keys := h.KeyRing.GetAllValidPublicKeys()
+	var lastErr error
+	for _, pubKey := range keys {
+		authorizer, err := b.Authorizer(pubKey)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		rule, err := parser.FromStringPolicy("allow if true")
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		authorizer.AddPolicy(rule)
+
+		if err := authorizer.Authorize(); err == nil {
+			return b, nil
+		} else {
+			lastErr = err
+		}
 	}
+
+	return nil, fmt.Errorf("no valid key found for verification: %v", lastErr)
 }
 
 func (h *Hub) parseAndVerifyJWT(ctx context.Context, jwtStr string, allowedAudiences []string) (jwt.MapClaims, *oidc.IDToken, error) {
@@ -539,31 +506,7 @@ func (h *Hub) mintBiscuitToken(claims jwt.MapClaims, token *oidc.IDToken, remote
 
 // startWatchdog periodically checks for peers that have connected but not completed OIDC
 // authentication within the grace period, and evicts them from the network.
-func (h *Hub) startWatchdog(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(10 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			h.gater.mu.Lock()
-			now := time.Now()
-			for pID, connectedAt := range h.gater.pending {
-				if now.Sub(connectedAt) > GracePeriod {
-					logger.Warnf("[Security] Evicting unauthenticated peer: %s", pID)
-					if err := h.Host.Network().ClosePeer(pID); err != nil {
-						logger.Errorf("[Security] Closing unauthenticated peer %s: %v", pID, err)
-					}
-					delete(h.gater.pending, pID)
-				}
-			}
-			h.gater.mu.Unlock()
-		}
-	}()
-}
+
 
 func (h *Hub) startRotation(ctx context.Context) {
 	if keyRotationInterval <= 0 {
@@ -673,13 +616,12 @@ func main() {
 			if err != nil {
 				logger.Fatal(err)
 			}
-			h.Host.SetStreamHandler(api.EnrollProtocolID, h.handleEnroll)
+			h.Host.SetStreamHandler(api.AuthProtocolID, h.handleAuthHandshake)
 
 			// Start key rotation if enabled
 			h.startRotation(ctx)
 
-			// Watchdog: Expel peers that connect but never finish authentication
-			h.startWatchdog(ctx)
+
 
 			startHTTPServer(h, bindAddress, adminToken, tlsCertFile, tlsKeyFile, tlsCAFile, &isHubReady)
 

--- a/cmd/sam-hub/server.go
+++ b/cmd/sam-hub/server.go
@@ -15,20 +15,27 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync/atomic"
 
+	"github.com/google/sam/api"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/protobuf/proto"
 )
 
 // startHTTPServer starts the HTTP/HTTPS server for metrics, healthz, and admin commands.
 func startHTTPServer(h *Hub, bindAddr string, adminToken string, tlsCertFile string, tlsKeyFile string, tlsCAFile string, isHubReady *atomic.Bool) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/register", handleRegisterHTTP(h))
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if isHubReady.Load() {
 			w.WriteHeader(http.StatusOK)
@@ -84,5 +91,118 @@ func startHTTPServer(h *Hub, bindAddr string, adminToken string, tlsCertFile str
 				logger.Errorf("HTTP server failed: %v", err)
 			}
 		}()
+	}
+}
+
+func handleRegisterHTTP(h *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read body", http.StatusBadRequest)
+			return
+		}
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				logger.Errorf("failed to close request body: %v", err)
+			}
+		}()
+
+		var req api.EnrollRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
+
+		if !h.limiter.Allow() {
+			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
+		logger.Infow("New HTTP enrollment request", "peer_id", req.PeerId)
+
+		ctx, cancel := context.WithTimeout(context.Background(), JWTVerificationTimeout)
+		defer cancel()
+
+		claims, token, err := h.parseAndVerifyJWT(ctx, req.Jwt, h.AllowedAudiences)
+		if err != nil {
+			logger.Errorw("JWT verification failed", "peer_id", req.PeerId, "error", err)
+			http.Error(w, "JWT validation failed: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		pID, err := peer.Decode(req.PeerId)
+		if err != nil {
+			logger.Errorw("Invalid Peer ID", "peer_id", req.PeerId, "error", err)
+			http.Error(w, "Invalid Peer ID", http.StatusBadRequest)
+			return
+		}
+
+		biscuitData, err := h.mintBiscuitToken(claims, token, pID)
+		if err != nil {
+			logger.Errorw("Biscuit minting failed", "peer_id", req.PeerId, "error", err)
+			http.Error(w, "Failed to mint biscuit", http.StatusInternalServerError)
+			return
+		}
+
+		h.gater.mu.Lock()
+		if !h.gater.authenticated[pID] {
+			samHubActiveNodes.Inc()
+		}
+		h.gater.authenticated[pID] = true
+		h.gater.mu.Unlock()
+
+		var authPeers []peer.ID
+		h.gater.mu.Lock()
+		for p := range h.gater.authenticated {
+			authPeers = append(authPeers, p)
+		}
+		h.gater.mu.Unlock()
+
+		var knownPeers []string
+		for _, p := range authPeers {
+			knownPeers = append(knownPeers, p.String())
+		}
+
+		var hubAddrs []string
+		if len(h.ExternalAddrs) > 0 {
+			for _, addr := range h.ExternalAddrs {
+				fullAddr := addr
+				if !strings.Contains(addr, "/p2p/") {
+					fullAddr = addr + "/p2p/" + h.Host.ID().String()
+				}
+				hubAddrs = append(hubAddrs, fullAddr)
+			}
+		} else {
+			for _, addr := range h.Host.Addrs() {
+				hubAddrs = append(hubAddrs, addr.String()+"/p2p/"+h.Host.ID().String())
+			}
+		}
+
+		resp := &api.EnrollResponse{
+			BiscuitToken: biscuitData,
+			HubPublicKey: h.KeyRing.GetCurrentPublicKey(),
+			HubAddresses: hubAddrs,
+			Expiration:   token.Expiry.Unix(),
+			KnownPeers:   knownPeers,
+		}
+
+		respData, err := proto.Marshal(resp)
+		if err != nil {
+			logger.Errorf("[Enroll] Failed to marshal response: %v", err)
+			http.Error(w, "Failed to serialize response", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respData)
+
+		logger.Infow("Successfully enrolled peer via HTTP", "peer_id", req.PeerId)
+		samHubEnrollmentTotal.WithLabelValues("success").Inc()
 	}
 }

--- a/cmd/sam-hub/server.go
+++ b/cmd/sam-hub/server.go
@@ -149,6 +149,13 @@ func handleRegisterHTTP(h *Hub) http.HandlerFunc {
 			return
 		}
 
+		h.gater.mu.Lock()
+		if !h.gater.authenticated[pID] {
+			samHubActiveNodes.Inc()
+		}
+		h.gater.authenticated[pID] = true
+		h.gater.mu.Unlock()
+
 		var authPeers []peer.ID
 		h.gater.mu.Lock()
 		for p := range h.gater.authenticated {

--- a/cmd/sam-hub/server.go
+++ b/cmd/sam-hub/server.go
@@ -149,13 +149,6 @@ func handleRegisterHTTP(h *Hub) http.HandlerFunc {
 			return
 		}
 
-		h.gater.mu.Lock()
-		if !h.gater.authenticated[pID] {
-			samHubActiveNodes.Inc()
-		}
-		h.gater.authenticated[pID] = true
-		h.gater.mu.Unlock()
-
 		var authPeers []peer.ID
 		h.gater.mu.Lock()
 		for p := range h.gater.authenticated {

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -55,7 +55,7 @@ var (
 	jwtPathFlag           string
 	clientIDFlag          string
 	clientSecretFlag      string
-	tokenURLFlag          string
+	oidcIssuerFlag        string
 	deviceAuthURLFlag     string
 	audienceFlag          string
 	hubPublicKeyFlag      string
@@ -148,11 +148,15 @@ func main() {
 					logger.Fatalf("Failed to read JWT file: %v", err)
 				}
 				jwtStr = strings.TrimSpace(string(data))
-			} else if tokenURLFlag != "" {
-				logger.Info("Fetching JWT via OIDC Client Credentials...")
+			} else if oidcIssuerFlag != "" {
+				logger.Info("Discovering OIDC endpoints...")
 				dummyNode := &SamNode{}
-				var err error
-				jwtStr, err = dummyNode.FetchJWT(context.Background(), tokenURLFlag, clientIDFlag, clientSecretFlag)
+				tokenURL, err := dummyNode.DiscoverTokenURL(context.Background(), oidcIssuerFlag)
+				if err != nil {
+					logger.Fatalf("Failed to discover OIDC endpoints: %v", err)
+				}
+				logger.Info("Fetching JWT via OIDC Client Credentials...")
+				jwtStr, err = dummyNode.FetchJWT(context.Background(), tokenURL, clientIDFlag, clientSecretFlag)
 				if err != nil {
 					logger.Fatalf("Failed to fetch JWT: %v", err)
 				}
@@ -220,7 +224,7 @@ func main() {
 			}
 
 			// Start renewal loop
-			node.StartRenewalLoop(ctx, tokenURLFlag, clientIDFlag, clientSecretFlag, jwtPathFlag)
+			node.StartRenewalLoop(ctx, oidcIssuerFlag, clientIDFlag, clientSecretFlag, jwtPathFlag)
 
 			node.Host.SetStreamHandler(api.AuthProtocolID, node.HandleAuthHandshake)
 
@@ -261,10 +265,20 @@ func main() {
 
 			dummyNode := &SamNode{Store: store}
 			deviceAuthURL := deviceAuthURLFlag
+			tokenURL := ""
+
+			if oidcIssuerFlag != "" {
+				logger.Info("Discovering OIDC endpoints...")
+				var err error
+				tokenURL, deviceAuthURL, err = dummyNode.DiscoverEndpoints(context.Background(), oidcIssuerFlag)
+				if err != nil {
+					logger.Fatalf("Failed to discover OIDC endpoints: %v", err)
+				}
+			}
+
 			if deviceAuthURL == "" {
 				deviceAuthURL = "https://oauth2.googleapis.com/device/code"
 			}
-			tokenURL := tokenURLFlag
 			if tokenURL == "" {
 				tokenURL = "https://oauth2.googleapis.com/token"
 			}
@@ -332,7 +346,7 @@ func main() {
 	runCmd.Flags().StringVar(&tlsCAFlag, "tls-ca", "", "Path to TLS CA for sidecar API mTLS")
 	rootCmd.PersistentFlags().StringVar(&hubAddr, "hub", DefaultHubURL, "Hub URL")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", DefaultConfigFile, "Path to sam-node.yaml configuration file")
-	rootCmd.PersistentFlags().StringVar(&tokenURLFlag, "token-url", "", "OIDC Token URL")
+	rootCmd.PersistentFlags().StringVar(&oidcIssuerFlag, "oidc-issuer", "", "OIDC Issuer URL")
 	rootCmd.PersistentFlags().StringVar(&deviceAuthURLFlag, "device-auth-url", "", "OIDC Device Authorization URL")
 	rootCmd.PersistentFlags().StringVar(&audienceFlag, "audience", api.DefaultAudience, "OIDC Audience")
 

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -15,11 +15,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -29,7 +32,7 @@ import (
 	"github.com/google/sam/api"
 	golog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-msgio"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
@@ -180,26 +183,28 @@ func main() {
 			} else {
 				// We have a new JWT (from flag or interactive login), need to enroll
 				var initHubAddrs []multiaddr.Multiaddr
-				ma, err := multiaddr.NewMultiaddr(hubAddr)
-				if err == nil {
-					initHubAddrs = []multiaddr.Multiaddr{ma}
-				} else {
-					// Try parsing as host:port
-					host, port, err := net.SplitHostPort(hubAddr)
+				if !strings.HasPrefix(hubAddr, "http://") && !strings.HasPrefix(hubAddr, "https://") {
+					ma, err := multiaddr.NewMultiaddr(hubAddr)
 					if err == nil {
-						ip := net.ParseIP(host)
-						var maddr multiaddr.Multiaddr
-						if ip != nil {
-							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
-						} else {
-							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
-						}
-						initHubAddrs = []multiaddr.Multiaddr{maddr}
+						initHubAddrs = []multiaddr.Multiaddr{ma}
 					} else {
-						if len(hubAddrs) > 0 {
-							initHubAddrs = hubAddrs
+						// Try parsing as host:port
+						host, port, err := net.SplitHostPort(hubAddr)
+						if err == nil {
+							ip := net.ParseIP(host)
+							var maddr multiaddr.Multiaddr
+							if ip != nil {
+								maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
+							} else {
+								maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
+							}
+							initHubAddrs = []multiaddr.Multiaddr{maddr}
 						} else {
-							logger.Fatalf("Invalid hub address and no stored config: %v. You can use community maintained meshes like hub.sam-mesh.dev (Production) or bananas.sam-mesh.dev (Testnet)", err)
+							if len(hubAddrs) > 0 {
+								initHubAddrs = hubAddrs
+							} else {
+								logger.Fatalf("Invalid hub address and no stored config: %v. You can use community maintained meshes like hub.sam-mesh.dev (Production) or bananas.sam-mesh.dev (Testnet)", err)
+							}
 						}
 					}
 				}
@@ -293,22 +298,24 @@ func main() {
 
 			// Connect to Hub and Enroll
 			var initHubAddrs []multiaddr.Multiaddr
-			ma, err := multiaddr.NewMultiaddr(hubAddr)
-			if err == nil {
-				initHubAddrs = []multiaddr.Multiaddr{ma}
-			} else {
-				host, port, err := net.SplitHostPort(hubAddr)
+			if !strings.HasPrefix(hubAddr, "http://") && !strings.HasPrefix(hubAddr, "https://") {
+				ma, err := multiaddr.NewMultiaddr(hubAddr)
 				if err == nil {
-					ip := net.ParseIP(host)
-					var maddr multiaddr.Multiaddr
-					if ip != nil {
-						maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
-					} else {
-						maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
-					}
-					initHubAddrs = []multiaddr.Multiaddr{maddr}
+					initHubAddrs = []multiaddr.Multiaddr{ma}
 				} else {
-					logger.Fatalf("Invalid hub address: %v", err)
+					host, port, err := net.SplitHostPort(hubAddr)
+					if err == nil {
+						ip := net.ParseIP(host)
+						var maddr multiaddr.Multiaddr
+						if ip != nil {
+							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
+						} else {
+							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
+						}
+						initHubAddrs = []multiaddr.Multiaddr{maddr}
+					} else {
+						logger.Fatalf("Invalid hub address: %v", err)
+					}
 				}
 			}
 
@@ -391,16 +398,6 @@ func getOrGenerateKey(s *Store) crypto.PrivKey {
 	return priv
 }
 func (n *SamNode) Enroll(ctx context.Context, jwt string) error {
-	if n.HubPeerID == "" {
-		return fmt.Errorf("not connected to any hub")
-	}
-
-	s, err := n.Host.NewStream(ctx, n.HubPeerID, api.EnrollProtocolID)
-	if err != nil {
-		return fmt.Errorf("failed to open enroll stream: %v", err)
-	}
-	defer func() { _ = s.Close() }()
-
 	req := &api.EnrollRequest{
 		Jwt:    jwt,
 		PeerId: n.Host.ID().String(),
@@ -410,55 +407,97 @@ func (n *SamNode) Enroll(ctx context.Context, jwt string) error {
 		return fmt.Errorf("failed to marshal enroll request: %v", err)
 	}
 
-	writer := msgio.NewVarintWriter(s)
-	if err := writer.WriteMsg(data); err != nil {
-		return fmt.Errorf("failed to write enroll request: %v", err)
+	if !strings.HasPrefix(hubAddr, "http://") && !strings.HasPrefix(hubAddr, "https://") {
+		return fmt.Errorf("hub address must be an HTTP or HTTPS URL for enrollment: %s", hubAddr)
 	}
+	url := hubAddr + "/register"
+	logger.Infof("Enrolling via HTTP at %s", url)
 
-	reader := msgio.NewVarintReaderSize(s, 1024*64)
-	respMsg, err := reader.ReadMsg()
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("failed to read enroll response: %v", err)
+		return fmt.Errorf("failed to create HTTP request: %v", err)
 	}
-	defer reader.ReleaseMsg(respMsg)
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 
-	var resp api.EnrollResponse
-	if err := proto.Unmarshal(respMsg, &resp); err != nil {
-		return fmt.Errorf("failed to unmarshal enroll response: %v", err)
+	client := &http.Client{}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Errorf("failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("enrollment failed with status %s: %s", resp.Status, string(body))
 	}
 
-	if resp.ErrorMessage != "" {
-		return fmt.Errorf("enrollment failed: %s", resp.ErrorMessage)
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	if len(resp.BiscuitToken) == 0 {
+	var enrollResp api.EnrollResponse
+	if err := proto.Unmarshal(respData, &enrollResp); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	if enrollResp.ErrorMessage != "" {
+		return fmt.Errorf("enrollment failed: %s", enrollResp.ErrorMessage)
+	}
+
+	if len(enrollResp.BiscuitToken) == 0 {
 		return fmt.Errorf("received empty biscuit token")
 	}
 
-	if err := n.Store.SaveIdentity(resp.BiscuitToken); err != nil {
+	if err := n.Store.SaveIdentity(enrollResp.BiscuitToken); err != nil {
 		return fmt.Errorf("failed to save identity: %v", err)
 	}
 
-	if err := n.Store.SaveIdentityExpiration(resp.Expiration); err != nil {
+	if err := n.Store.SaveIdentityExpiration(enrollResp.Expiration); err != nil {
 		return fmt.Errorf("failed to save identity expiration: %v", err)
 	}
 
-	if err := n.Store.SaveHubConfig(resp.HubPublicKey, resp.HubAddresses); err != nil {
+	if err := n.Store.SaveHubConfig(enrollResp.HubPublicKey, enrollResp.HubAddresses); err != nil {
 		return fmt.Errorf("failed to save hub config: %v", err)
 	}
 
 	n.keysMu.Lock()
-	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(resp.HubPublicKey), ReceivedAt: time.Now()})
+	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(enrollResp.HubPublicKey), ReceivedAt: time.Now()})
 	n.keysMu.Unlock()
 
 	// Add known peers from response
 	n.mu.Lock()
-	for _, p := range resp.KnownPeers {
+	for _, p := range enrollResp.KnownPeers {
 		n.knownPeers[p] = true
 		fmt.Printf("[Enroll] Added known peer from hub: %s\n", p)
 	}
 	n.mu.Unlock()
 
-	fmt.Println("Successfully enrolled and stored identity and hub config.")
+	// Connect to hub after enrollment to join the mesh
+	for _, addrStr := range enrollResp.HubAddresses {
+		addr, err := multiaddr.NewMultiaddr(addrStr)
+		if err != nil {
+			logger.Warnf("Failed to parse hub address from response: %v", err)
+			continue
+		}
+		addrInfo, err := peer.AddrInfoFromP2pAddr(addr)
+		if err != nil {
+			logger.Warnf("Failed to get AddrInfo from hub address: %v", err)
+			continue
+		}
+		if err := n.Host.Connect(ctx, *addrInfo); err != nil {
+			logger.Warnf("Failed to connect to hub after enrollment: %v", err)
+		} else {
+			logger.Infof("Successfully connected to hub via libp2p after enrollment")
+			n.HubPeerID = addrInfo.ID
+			break
+		}
+	}
+
+	fmt.Println("Successfully enrolled via HTTP and stored identity and hub config.")
 	return nil
 }

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/sam/api"
 	golog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
@@ -477,23 +476,16 @@ func (n *SamNode) Enroll(ctx context.Context, jwt string) error {
 	}
 	n.mu.Unlock()
 
-	// Connect to hub after enrollment to join the mesh
+	// Connect and Auth to hub after enrollment to join the mesh
 	for _, addrStr := range enrollResp.HubAddresses {
 		addr, err := multiaddr.NewMultiaddr(addrStr)
 		if err != nil {
 			logger.Warnf("Failed to parse hub address from response: %v", err)
 			continue
 		}
-		addrInfo, err := peer.AddrInfoFromP2pAddr(addr)
-		if err != nil {
-			logger.Warnf("Failed to get AddrInfo from hub address: %v", err)
-			continue
-		}
-		if err := n.Host.Connect(ctx, *addrInfo); err != nil {
-			logger.Warnf("Failed to connect to hub after enrollment: %v", err)
+		if err := n.ConnectAndAuthWithHub(ctx, addr); err != nil {
+			logger.Warnf("Failed to connect and auth with hub after enrollment: %v", err)
 		} else {
-			logger.Infof("Successfully connected to hub via libp2p after enrollment")
-			n.HubPeerID = addrInfo.ID
 			break
 		}
 	}

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -418,7 +418,9 @@ func (n *SamNode) Enroll(ctx context.Context, jwt string) error {
 	}
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %v", err)

--- a/cmd/sam-node/middleware.go
+++ b/cmd/sam-node/middleware.go
@@ -149,10 +149,15 @@ func (n *SamNode) WithBiscuitAuth(next network.StreamHandler) network.StreamHand
 			var jwtStr string
 			var err error
 
-			if tokenURLFlag != "" {
-				jwtStr, err = n.FetchJWT(context.Background(), tokenURLFlag, clientIDFlag, clientSecretFlag)
+			if oidcIssuerFlag != "" {
+				tokenURL, err := n.DiscoverTokenURL(context.Background(), oidcIssuerFlag)
 				if err != nil {
-					logger.Errorf("[Auth] Failed to fetch JWT for fallback: %v", err)
+					logger.Errorf("[Auth] Failed to discover OIDC endpoints for fallback: %v", err)
+				} else {
+					jwtStr, err = n.FetchJWT(context.Background(), tokenURL, clientIDFlag, clientSecretFlag)
+					if err != nil {
+						logger.Errorf("[Auth] Failed to fetch JWT for fallback: %v", err)
+					}
 				}
 			} else if jwtPathFlag != "" {
 				data, err := os.ReadFile(jwtPathFlag)

--- a/cmd/sam-node/node.go
+++ b/cmd/sam-node/node.go
@@ -301,7 +301,7 @@ func NewSamNode(ctx context.Context, privKey crypto.PrivKey, hubPubKey ed25519.P
 	return node, nil
 }
 
-func (n *SamNode) StartRenewalLoop(ctx context.Context, tokenURL, clientID, clientSecret, jwtPath string) {
+func (n *SamNode) StartRenewalLoop(ctx context.Context, issuerURL, clientID, clientSecret, jwtPath string) {
 	go func() {
 		for {
 			var renewAfter = DefaultRenewalFallback // Default fallback
@@ -329,8 +329,12 @@ func (n *SamNode) StartRenewalLoop(ctx context.Context, tokenURL, clientID, clie
 			case <-timer.C:
 				fmt.Println("Renewing enrollment...")
 				var newJWT string
-				if tokenURL != "" {
-					var err error
+				if issuerURL != "" {
+					tokenURL, err := n.DiscoverTokenURL(ctx, issuerURL)
+					if err != nil {
+						fmt.Printf("Failed to discover OIDC endpoints for renewal: %v\n", err)
+						continue
+					}
 					newJWT, err = n.FetchJWT(ctx, tokenURL, clientID, clientSecret)
 					if err != nil {
 						fmt.Printf("Failed to fetch JWT for renewal: %v\n", err)

--- a/cmd/sam-node/node.go
+++ b/cmd/sam-node/node.go
@@ -191,32 +191,11 @@ func NewSamNode(ctx context.Context, privKey crypto.PrivKey, hubPubKey ed25519.P
 		return nil, fmt.Errorf("failed to bootstrap DHT: %w", err)
 	}
 
-	// Bootstrap: Connect to the Hub
+	// Bootstrap: Connect and Auth to the Hub
 	for _, addr := range hubAddrs {
-		addrInfo, err := peer.AddrInfoFromP2pAddr(addr)
-		if err != nil || addrInfo == nil {
-			// Try to connect without Peer ID in address
-			addrInfo = &peer.AddrInfo{
-				Addrs: []multiaddr.Multiaddr{addr},
-			}
-			logger.Warn("[AuthN] Connecting to hub without Peer ID verification in address.")
-		}
-		if err := h.Connect(ctx, *addrInfo); err != nil {
-			logger.Warnf("[AuthN] Failed to bootstrap to hub %s: %v", addr, err)
+		if err := node.ConnectAndAuthWithHub(ctx, addr); err != nil {
+			logger.Warnf("[AuthN] Failed to bootstrap and auth with hub %s: %v", addr, err)
 		} else {
-			if addrInfo.ID == "" {
-				// Discover Peer ID from connection
-				for _, c := range h.Network().Conns() {
-					if c.RemoteMultiaddr().Equal(addr) {
-						node.HubPeerID = c.RemotePeer()
-						logger.Infof("[AuthN] Connected to hub (discovered PeerID): %s", node.HubPeerID)
-						break
-					}
-				}
-			} else {
-				node.HubPeerID = addrInfo.ID
-				logger.Infof("[AuthN] Connected to hub: %s", addrInfo.ID)
-			}
 			break
 		}
 	}
@@ -299,6 +278,69 @@ func NewSamNode(ctx context.Context, privKey crypto.PrivKey, hubPubKey ed25519.P
 	}
 
 	return node, nil
+}
+
+func (n *SamNode) ConnectAndAuthWithHub(ctx context.Context, addr multiaddr.Multiaddr) error {
+	addrInfo, err := peer.AddrInfoFromP2pAddr(addr)
+	if err != nil {
+		return fmt.Errorf("failed to get AddrInfo from multiaddr: %w", err)
+	}
+
+	if err := n.Host.Connect(ctx, *addrInfo); err != nil {
+		return fmt.Errorf("failed to connect to hub %s: %w", addr, err)
+	}
+
+	n.HubPeerID = addrInfo.ID
+	logger.Infof("[AuthN] Connected to hub: %s", addrInfo.ID)
+
+	// Load biscuit from store
+	biscuitBytes, err := n.Store.LoadIdentity()
+	if err != nil {
+		return fmt.Errorf("failed to load identity from store: %w", err)
+	}
+	if len(biscuitBytes) == 0 {
+		return fmt.Errorf("no identity biscuit found in store")
+	}
+
+	// Open auth stream
+	s, err := n.Host.NewStream(ctx, addrInfo.ID, api.AuthProtocolID)
+	if err != nil {
+		return fmt.Errorf("failed to open auth stream to hub: %w", err)
+	}
+	defer func() {
+		if err := s.Close(); err != nil {
+			logger.Errorf("failed to close stream: %v", err)
+		}
+	}()
+
+	writer := msgio.NewVarintWriter(s)
+	authFrame := &api.AuthFrame{Biscuit: biscuitBytes}
+	data, err := proto.Marshal(authFrame)
+	if err != nil {
+		return fmt.Errorf("failed to marshal auth frame: %w", err)
+	}
+	if err := writer.WriteMsg(data); err != nil {
+		return fmt.Errorf("failed to write auth frame: %w", err)
+	}
+
+	reader := msgio.NewVarintReaderSize(s, 1024*64)
+	respMsg, err := reader.ReadMsg()
+	if err != nil {
+		return fmt.Errorf("failed to read auth response: %w", err)
+	}
+	defer reader.ReleaseMsg(respMsg)
+
+	var resp api.AuthResponse
+	if err := proto.Unmarshal(respMsg, &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal auth response: %w", err)
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("auth failed: %s", resp.Error)
+	}
+
+	logger.Infof("[AuthN] Successfully authenticated with hub via libp2p")
+	return nil
 }
 
 func (n *SamNode) StartRenewalLoop(ctx context.Context, issuerURL, clientID, clientSecret, jwtPath string) {

--- a/cmd/sam-node/oidc.go
+++ b/cmd/sam-node/oidc.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -177,4 +178,38 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, deviceAuthURL, tokenURL,
 			}
 		}
 	}
+}
+
+// DiscoverTokenURL discovers the token URL from the OIDC issuer.
+func (n *SamNode) DiscoverTokenURL(ctx context.Context, issuerURL string) (string, error) {
+	provider, err := oidc.NewProvider(ctx, issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to create OIDC provider: %w", err)
+	}
+	var claims struct {
+		TokenURL string `json:"token_endpoint"`
+	}
+	if err := provider.Claims(&claims); err != nil {
+		return "", fmt.Errorf("failed to extract claims: %w", err)
+	}
+	if claims.TokenURL == "" {
+		return "", fmt.Errorf("token_endpoint not found in discovery document")
+	}
+	return claims.TokenURL, nil
+}
+
+// DiscoverEndpoints discovers both token and device auth endpoints.
+func (n *SamNode) DiscoverEndpoints(ctx context.Context, issuerURL string) (tokenURL, deviceURL string, err error) {
+	provider, err := oidc.NewProvider(ctx, issuerURL)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create OIDC provider: %w", err)
+	}
+	var claims struct {
+		TokenURL  string `json:"token_endpoint"`
+		DeviceURL string `json:"device_authorization_endpoint"`
+	}
+	if err := provider.Claims(&claims); err != nil {
+		return "", "", fmt.Errorf("failed to extract claims: %w", err)
+	}
+	return claims.TokenURL, claims.DeviceURL, nil
 }

--- a/cmd/sam-node/oidc_test.go
+++ b/cmd/sam-node/oidc_test.go
@@ -92,3 +92,35 @@ func TestInteractiveLogin(t *testing.T) {
 		t.Errorf("Expected token 'id_token_abc', got '%s'", res.token)
 	}
 }
+
+func TestDiscoverEndpoints(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                        "http://" + r.Host,
+			"token_endpoint":                "http://" + r.Host + "/token",
+			"device_authorization_endpoint": "http://" + r.Host + "/device/code",
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{}
+	ctx := context.Background()
+
+	tokenURL, deviceURL, err := node.DiscoverEndpoints(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("DiscoverEndpoints failed: %v", err)
+	}
+
+	if tokenURL != server.URL+"/token" {
+		t.Errorf("Expected tokenURL %s, got %s", server.URL+"/token", tokenURL)
+	}
+	if deviceURL != server.URL+"/device/code" {
+		t.Errorf("Expected deviceURL %s, got %s", server.URL+"/device/code", deviceURL)
+	}
+}

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -60,7 +60,7 @@ teardown() {
     -v "${data_vol}:/root/.config/sam-mesh" \
     -i \
     "sam-node:local" \
-    login --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" --token-url "http://mock-oidc:18080/token" --device-auth-url "http://mock-oidc:18080/device/code"
+    login --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" --oidc-issuer "http://mock-oidc:18080"
     
   # Now run the node with the stored identity
   docker run -d \

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -60,7 +60,7 @@ teardown() {
     -v "${data_vol}:/root/.config/sam-mesh" \
     -i \
     "sam-node:local" \
-    login --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" --oidc-issuer "http://mock-oidc:18080"
+    login --hub "http://sam-hub:9090" --oidc-issuer "http://mock-oidc:18080"
     
   # Now run the node with the stored identity
   docker run -d \

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -69,7 +69,7 @@ teardown() {
     -v "${data_vol}:/root/.config/sam-mesh" \
     "sam-node:local" \
     run \
-    --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}"
+    --hub "http://sam-hub:9090"
 
   mesh_wait_for_log "${node_name}" "Using stored identity." 20
   
@@ -110,7 +110,7 @@ teardown() {
     -v "${token_vol}:/var/run/secrets/tokens" \
     "sam-node:local" \
     run \
-    --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
+    --hub "http://sam-hub:9090" \
     --jwt-path "/var/run/secrets/tokens/sa-token"
 
   mesh_wait_for_log "${node_name}" "SAM Node Online" 20

--- a/tests/e2e/key_rotation_test.bats
+++ b/tests/e2e/key_rotation_test.bats
@@ -38,6 +38,7 @@ teardown() {
     --key "${key}" \
     --listen "/ip4/0.0.0.0/udp/4001/quic-v1" \
     --listen "/ip4/0.0.0.0/tcp/4002" \
+    --external-multiaddr "/dns4/sam-hub/tcp/4002" \
     --mesh "e2e-mesh" \
     --key-rotation-interval 5s >/dev/null
 

--- a/tests/e2e/kind_wi.bats
+++ b/tests/e2e/kind_wi.bats
@@ -127,8 +127,12 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 4002
+  - name: p2p
+    port: 4002
     targetPort: 4002
+  - name: http
+    port: 9090
+    targetPort: 9090
   selector:
     app: sam-hub
 EOF
@@ -176,7 +180,7 @@ spec:
         command: ["/sam-node", "run"]
         args:
         - "--hub"
-        - "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}"
+        - "http://sam-hub:9090"
         - "--jwt-path"
         - "/var/run/secrets/tokens/sam-token"
         volumeMounts:

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -38,7 +38,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
   }
 
   mesh_build_runtime_image() {
-    docker build \
+    docker build --no-cache \
       -f tests/e2e/docker/Dockerfile.sam-runtime \
       -t "${MESH_RUNTIME_IMAGE}" \
       . >/dev/null

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -243,7 +243,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
       --client-id "sam-mesh-audience" \
       --client-secret "sam-e2e-secret" \
-      --token-url "http://mock-oidc:18080/token" \
+      --oidc-issuer "http://mock-oidc:18080" \
       --listen "/ip4/0.0.0.0/udp/5001/quic-v1" \
       --listen "/ip4/0.0.0.0/tcp/5002" \
       --bind-addr "0.0.0.0:8080" \

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -47,9 +47,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
   mesh_setup_env() {
     mesh_cleanup_stale_resources
     
-    if ! docker image inspect "${MESH_RUNTIME_IMAGE}" >/dev/null 2>&1; then
-      mesh_build_runtime_image
-    fi
+    mesh_build_runtime_image
 
     MESH_PREFIX="mesh-${BATS_TEST_NUMBER}-$$-$(date +%s)"
     MESH_NETWORK="${MESH_PREFIX}-net"
@@ -240,7 +238,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       "${MESH_RUNTIME_IMAGE}" \
       /usr/local/bin/sam-node run \
       ${flags} \
-      --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
+      --hub "http://sam-hub:9090" \
       --client-id "sam-mesh-audience" \
       --client-secret "sam-e2e-secret" \
       --oidc-issuer "http://mock-oidc:18080" \

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -211,6 +211,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       --key "${key}" \
       --listen "/ip4/0.0.0.0/udp/4001/quic-v1" \
       --listen "/ip4/0.0.0.0/tcp/4002" \
+      --external-multiaddr "/dns4/sam-hub/tcp/4002" \
       --mesh "e2e-mesh" >/dev/null
 
     MESH_CONTAINERS+=("${name}")

--- a/tests/e2e/policy.bats
+++ b/tests/e2e/policy.bats
@@ -210,7 +210,7 @@ EOF"
     -v "${POLICY_VOL}:/etc/sam" \
     "sam-node:local" \
     run \
-    --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
+    --hub "http://sam-hub:9090" \
     --client-id "sam-e2e" \
     --client-secret "sam-e2e-secret" \
     --oidc-issuer "http://mock-oidc:18080" \

--- a/tests/e2e/policy.bats
+++ b/tests/e2e/policy.bats
@@ -213,7 +213,7 @@ EOF"
     --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
     --client-id "sam-e2e" \
     --client-secret "sam-e2e-secret" \
-    --token-url "http://mock-oidc:18080/token" \
+    --oidc-issuer "http://mock-oidc:18080" \
     --listen "/ip4/0.0.0.0/udp/5001/quic-v1" \
     --listen "/ip4/0.0.0.0/tcp/5002" \
     --bind-addr "0.0.0.0:8080" \

--- a/tests/integration/fallback_test.go
+++ b/tests/integration/fallback_test.go
@@ -27,13 +27,15 @@ import (
 	"testing"
 	"time"
 
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/biscuit-auth/biscuit-go/v2/parser"
 	"github.com/google/sam/api"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-msgio"
 	"github.com/multiformats/go-multiaddr"
@@ -261,10 +263,24 @@ func startMockHubDynamic(t *testing.T, pubA, pubB ed25519.PublicKey) (peer.ID, s
 	}
 
 	var callCount int
-	h.SetStreamHandler(api.EnrollProtocolID, func(s network.Stream) {
-		defer func() { _ = s.Close() }()
-		callCount++
+	mux := http.NewServeMux()
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read body", http.StatusBadRequest)
+			return
+		}
+		var req api.EnrollRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
 
+		callCount++
 		var pub []byte
 		if callCount == 1 {
 			pub = pubA
@@ -276,18 +292,27 @@ func startMockHubDynamic(t *testing.T, pubA, pubB ed25519.PublicKey) (peer.ID, s
 			BiscuitToken: []byte("mock-biscuit-token"),
 			HubPublicKey: pub,
 			HubAddresses: []string{h.Addrs()[0].String() + "/p2p/" + h.ID().String()},
+			KnownPeers:   []string{},
 		}
-		data, _ := proto.Marshal(resp)
-		writer := msgio.NewVarintWriter(s)
-		_ = writer.WriteMsg(data)
+		data, err := proto.Marshal(resp)
+		if err != nil {
+			http.Error(w, "Failed to marshal response", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
 	})
 
+	httpServer := httptest.NewServer(mux)
+
 	t.Cleanup(func() {
+		httpServer.Close()
 		_ = kdht.Close()
 		_ = h.Close()
 	})
 
-	return h.ID(), h.Addrs()[0].String() + "/p2p/" + h.ID().String()
+	return h.ID(), httpServer.URL
 }
 
 type safeBuffer struct {

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -37,6 +37,16 @@ func TestSamNodeLogin(t *testing.T) {
 
 	// Mock OIDC server for device flow
 	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                        "http://" + r.Host,
+			"token_endpoint":                "http://" + r.Host + "/token",
+			"device_authorization_endpoint": "http://" + r.Host + "/device/code",
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
 	mux.HandleFunc("/device/code", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{
@@ -70,8 +80,7 @@ func TestSamNodeLogin(t *testing.T) {
 		nodeBin,
 		"login",
 		"--hub", hubAddr,
-		"--token-url", server.URL+"/token",
-		"--device-auth-url", server.URL+"/device/code",
+		"--oidc-issuer", server.URL,
 	)
 	if err != nil {
 		t.Fatalf("login command failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)

--- a/tests/integration/minimal_helpers_test.go
+++ b/tests/integration/minimal_helpers_test.go
@@ -18,19 +18,19 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"github.com/google/sam/api"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-msgio"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -103,32 +103,47 @@ func startMockLibp2pHub(t *testing.T) (peer.ID, string) {
 		t.Fatalf("failed to create DHT on mock hub: %v", err)
 	}
 
-	h.SetStreamHandler(api.EnrollProtocolID, func(s network.Stream) {
-		defer func() { _ = s.Close() }()
+	// Start HTTP server for enrollment
+	mux := http.NewServeMux()
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read body", http.StatusBadRequest)
+			return
+		}
+		var req api.EnrollRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
 
-		// The following constants are mock values used for testing.
-		// 'mock-biscuit-token' is a dummy token string.
-		// 'mock-hub-pub-key' is a dummy public key string.
 		resp := &api.EnrollResponse{
 			BiscuitToken: []byte("mock-biscuit-token"),
 			HubPublicKey: []byte("mock-hub-pub-key"),
 			HubAddresses: []string{h.Addrs()[0].String() + "/p2p/" + h.ID().String()},
+			KnownPeers:   []string{},
 		}
 		data, err := proto.Marshal(resp)
 		if err != nil {
-			fmt.Printf("Failed to marshal mock response: %v\n", err)
+			http.Error(w, "Failed to marshal response", http.StatusInternalServerError)
 			return
 		}
-		writer := msgio.NewVarintWriter(s)
-		if err := writer.WriteMsg(data); err != nil {
-			fmt.Printf("Failed to write mock response: %v\n", err)
-		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
 	})
 
+	httpServer := httptest.NewServer(mux)
+
 	t.Cleanup(func() {
+		httpServer.Close()
 		_ = kdht.Close()
 		_ = h.Close()
 	})
 
-	return h.ID(), h.Addrs()[0].String() + "/p2p/" + h.ID().String()
+	return h.ID(), httpServer.URL
 }


### PR DESCRIPTION
Multiaddress are cryptic and also complicates the deployment of the control plane nodes to use a single loadbalancer and a deployment.

The new flow is nodes use http to enroll and obtain the bootstrap addresses and peers, and later join the network