### PR TITLE
test: refactor and unify mock hub enrollment logic

### DIFF
--- a/.github/k8s/dex-config.yaml
+++ b/.github/k8s/dex-config.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dex
+  namespace: dex
+data:
+  config.yaml: |
+    # The public URL where Dex is accessible
+    issuer: https://auth.sam-mesh.dev
+
+    storage:
+      type: kubernetes
+      config:
+        inCluster: true
+
+    web:
+      # Serve plain HTTP locally; the GKE Ingress handles HTTPS termination
+      http: 0.0.0.0:5556
+
+    oauth2:
+      # Explicitly enable the Device Flow for headless CLI usage
+      grantTypes:
+        - "authorization_code"
+        - "refresh_token"
+        - "urn:ietf:params:oauth:grant-type:device_code"
+      skipApprovalScreen: true
+
+    connectors:
+    - type: google
+      id: google
+      name: Google
+      config:
+        clientID: $GOOGLE_CLIENT_ID
+        clientSecret: $GOOGLE_CLIENT_SECRET
+        redirectURI: https://auth.sam-mesh.dev/callback
+
+    - type: github
+      id: github
+      name: GitHub
+      config:
+        clientID: $GITHUB_CLIENT_ID
+        clientSecret: $GITHUB_CLIENT_SECRET
+        redirectURI: https://auth.sam-mesh.dev/callback
+
+    staticClients:
+    # This ID becomes the 'aud' claim in the JWT consumed by sam-hub
+    - id: sam-mesh-audience
+      name: 'SAM Mesh CLI'
+      secret: $CLI_OAUTH_SECRET
+      public: true # Allows PKCE flow for CLIs without exposing the secret
+      redirectURIs:
+      - 'http://127.0.0.1:8080/callback'
+      - 'http://localhost:8080/callback'

--- a/.github/k8s/dex-deployment.yaml
+++ b/.github/k8s/dex-deployment.yaml
@@ -1,0 +1,170 @@
+# Create the Google-managed certificate
+# gcloud certificate-manager certificates create dex-cert \
+#   --domains="auth.sam-mesh.dev" --global
+
+# Create a Certificate Map
+# gcloud certificate-manager maps create dex-cert-map
+
+# Bind the certificate to the map for your domain
+# gcloud certificate-manager maps entries create dex-cert-map-entry \
+#   --map="dex-cert-map" \
+#   --hostname="auth.sam-mesh.dev" \
+#   --certificates="dex-cert"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dex
+  namespace: dex
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: dex
+  labels:
+    app: dex
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      serviceAccountName: dex
+      containers:
+      - image: ghcr.io/dexidp/dex:v2.38.0
+        name: dex
+        command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+        ports:
+        - name: http
+          containerPort: 5556
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex/cfg
+        env:
+        # Dynamically pulls the values injected by your GitHub Actions pipeline
+        - name: GOOGLE_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: dex-secrets
+              key: google-client-id
+        - name: GOOGLE_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: dex-secrets
+              key: google-client-secret
+        - name: GITHUB_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: dex-secrets
+              key: github-client-id
+        - name: GITHUB_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: dex-secrets
+              key: github-client-secret
+        - name: CLI_OAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: dex-secrets
+              key: cli-oauth-secret
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+      volumes:
+      - name: config
+        configMap:
+          name: dex
+          items:
+          - key: config.yaml
+            path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: dex
+spec:
+  ports:
+  - name: dex
+    port: 5556
+    protocol: TCP
+    targetPort: 5556
+  selector:
+    app: dex
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: dex-healthcheck
+  namespace: dex
+spec:
+  default:
+    checkIntervalSec: 15
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 2
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz
+  targetRef:
+    group: ""
+    kind: Service
+    name: dex
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external-http-gateway
+  namespace: dex
+  annotations:
+    # Attach the Certificate Map
+    networking.gke.io/certmap: dex-cert-map
+spec:
+  # This provisions a Global External Application Load Balancer
+  gatewayClassName: gke-l7-global-external-managed
+  addresses:
+  - type: NamedAddress
+    value: auth-sam-mash # reserved static IP name
+  listeners:
+  - name: https
+    protocol: HTTPS
+    port: 443
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dex-route
+  namespace: dex
+spec:
+  parentRefs:
+  - name: external-http-gateway
+  hostnames:
+  - "auth.sam-mesh.dev"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: dex
+      port: 5556

--- a/.github/k8s/sam-hub-template.yaml
+++ b/.github/k8s/sam-hub-template.yaml
@@ -25,7 +25,7 @@ metadata:
   name: sam-hub-${ENV_NAME}
   namespace: ${NAMESPACE}
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: sam-hub-${ENV_NAME}
@@ -36,17 +36,36 @@ spec:
     spec:
       containers:
       - name: sam-hub
-        image: your-registry/sam-hub:${IMAGE_TAG}
+        image: ghcr.io/google/sam-hub:${IMAGE_TAG}
         ports:
         - containerPort: 4001
           protocol: TCP
+          name: libp2p-tcp
         - containerPort: 4001
           protocol: UDP
+          name: libp2p-udp
+        - containerPort: 9090
+          protocol: TCP
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: metrics
+          initialDelaySeconds: 15
+          periodSeconds: 20
         args:
         - "--listen=/ip4/0.0.0.0/tcp/4001,/ip4/0.0.0.0/udp/4001/quic-v1"
         - "--external-multiaddr=${EXTERNAL_MULTIADDR}"
-        
-        # Critical for multi-tenant clusters: prevent testnet from starving prod
+        # 1. Trust Dex for humans/Google/GitHub. 2. Trust GKE for internal Canaries.
+        - "--issuer=https://auth.sam-mesh.dev,https://container.googleapis.com/v1/projects/${GCP_PROJECT_ID}/locations/${CLUSTER_REGION}/clusters/${CLUSTER_NAME}"
+        # 1. Dex CLI client ID. 2. Canary projected volume audience.
+        - "--allowed-audiences=sam-mesh-audience,sam-hub-audience"
         resources:
           requests:
             cpu: 100m
@@ -54,3 +73,17 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: sam-hub-monitor-${ENV_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      app: sam-hub-${ENV_NAME}
+  endpoints:
+  - port: metrics
+    interval: 30s
+    path: /metrics

--- a/.github/k8s/sam-node-template.yaml
+++ b/.github/k8s/sam-node-template.yaml
@@ -22,13 +22,19 @@ data:
         # We call the injected busybox binary explicitly
         command: ["/shared/busybox", "sh", "-c", "while read line; do echo '{\"jsonrpc\": \"2.0\", \"id\": 1, \"result\": {\"status\": \"canary-alive\"}}'; done"]
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sam-node-sa
+  namespace: sam-canary-${ENV_NAME}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sam-canary-${ENV_NAME}
   namespace: sam-canary-${ENV_NAME}
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: sam-canary-${ENV_NAME}
@@ -37,6 +43,7 @@ spec:
       labels:
         app: sam-canary-${ENV_NAME}
     spec:
+      serviceAccountName: sam-node-sa
       # 1. The Init Container: Copies busybox to the shared volume
       initContainers:
       - name: inject-busybox
@@ -54,6 +61,7 @@ spec:
           - "run"
           - "--config=/etc/sam/sam-node.yaml"
           - "--hub=/dns4/sam-hub-${ENV_NAME}.sam-${ENV_NAME}.svc.cluster.local/udp/4001/quic-v1"
+          - "--jwt-path=/var/run/secrets/tokens/sam-token"
         ports:
         - containerPort: 8080
         resources:
@@ -68,6 +76,9 @@ spec:
           mountPath: /etc/sam
         - name: shared-bin
           mountPath: /shared
+        - name: sam-token
+          mountPath: /var/run/secrets/tokens
+          readOnly: true
           
       # 3. The Dummy MCP Backend Sidecar
       - name: mock-mcp-server
@@ -83,3 +94,10 @@ spec:
           name: sam-canary-config-${ENV_NAME}
       - name: shared-bin
         emptyDir: {}
+      - name: sam-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: sam-token
+              expirationSeconds: 3600
+              audience: "sam-hub-audience"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,7 @@ jobs:
       with:
         context: .
         file: Dockerfile.sam-hub
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
         push: true
         tags: ${{ steps.meta-hub.outputs.tags }}
         labels: ${{ steps.meta-hub.outputs.labels }}
@@ -76,7 +76,7 @@ jobs:
       with:
         context: .
         file: Dockerfile.sam-node
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
         push: true
         tags: ${{ steps.meta-node.outputs.tags }}
         labels: ${{ steps.meta-node.outputs.labels }}
@@ -121,8 +121,41 @@ jobs:
           export NAMESPACE="sam-${ENV_NAME}"
           export CANARY_NAMESPACE="sam-canary-${ENV_NAME}"
           
+          kubectl create namespace dex --dry-run=client -o yaml | kubectl apply -f -
           kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
           kubectl create namespace ${CANARY_NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Provision Dex Secrets
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GITHUB_CLIENT_ID: ${{ secrets.GHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.GHUB_CLIENT_SECRET }}
+          CLI_OAUTH_SECRET: ${{ secrets.CLI_OAUTH_SECRET }}
+        run: |
+          # Declaratively apply secrets without writing them to disk
+          kubectl create secret generic dex-secrets \
+            --namespace=dex \
+            --from-literal=google-client-id="${GOOGLE_CLIENT_ID}" \
+            --from-literal=google-client-secret="${GOOGLE_CLIENT_SECRET}" \
+            --from-literal=github-client-id="${GITHUB_CLIENT_ID}" \
+            --from-literal=github-client-secret="${GITHUB_CLIENT_SECRET}" \
+            --from-literal=cli-oauth-secret="${CLI_OAUTH_SECRET}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy Dex Resources
+        run: |
+          # Apply the Dex manifests
+          kubectl apply -f .github/k8s/dex-config.yaml
+          kubectl apply -f .github/k8s/dex-deployment.yaml
+
+          # Force a restart to pick up any changes to the secrets, and wait for readiness
+          kubectl rollout restart deployment/dex -n dex
+          kubectl rollout status deployment/dex -n dex --timeout=120s || {
+            echo "Dex Deployment failed! Rolling back..."
+            kubectl rollout undo deployment/dex -n dex
+            exit 1
+          }
 
       - name: Deploy Hub
         run: |
@@ -133,7 +166,10 @@ jobs:
           export EXTERNAL_MULTIADDR="${{ vars.EXTERNAL_MULTIADDR }}"
           export NAMESPACE="sam-${ENV_NAME}"
           export IMAGE_TAG="${{ env.IMAGE_TAG }}"
-          
+          export GCP_PROJECT_ID="${{ vars.GCP_PROJECT_ID }}"
+          export CLUSTER_REGION="${{ vars.CLUSTER_REGION }}"
+          export CLUSTER_NAME="${{ vars.CLUSTER_NAME }}"
+
           envsubst < .github/k8s/sam-hub-template.yaml | kubectl apply -f -
           
           kubectl rollout status deployment/sam-hub-${ENV_NAME} -n ${NAMESPACE} --timeout=120s || {
@@ -149,7 +185,7 @@ jobs:
           export CANARY_NAMESPACE="sam-canary-${ENV_NAME}"
           export IMAGE_TAG="${{ env.IMAGE_TAG }}"
           
-          envsubst < .github/k8s/sam-canary-template.yaml | kubectl apply -f -
+          envsubst < .github/k8s/sam-node-template.yaml | kubectl apply -f -
           
           kubectl rollout status deployment/sam-canary-${ENV_NAME} -n ${CANARY_NAMESPACE} --timeout=120s || {
             echo "Canary Deployment failed! Rolling back..."

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,16 +22,16 @@ jobs:
     
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Determine Image Tag
         run: |

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -23,7 +23,7 @@ jobs:
         go-version: '1.22'
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ docker-build-hub:
 	docker build -t sam-hub:local -f Dockerfile.sam-hub .
 
 docker-build-node:
-	docker build -t sam-node:local -f Dockerfile.sam-node .
+	docker build --no-cache -t sam-node:local -f Dockerfile.sam-node .
 
 docker-build-mock-oidc:
 	docker build -t sam-mock-oidc:local -f tests/e2e/docker/Dockerfile.mock-oidc .

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Or pass a token directly:
 
 ## Local MCP Server
 
-Each `sam-node` exposes a Model Context Protocol (MCP) server over a Unix domain socket to allow local processes to discover the capabilities of the local agent and get information from the mesh.
+Each `sam-node` exposes a Model Context Protocol (MCP) server over HTTP Server-Sent Events (SSE) to allow local processes to discover the capabilities of the local agent and get information from the mesh.
 
-By default, the socket listens at `<datadir>/mcp.sock`. You can change this with the `--mcp-socket` flag.
+By default, the server listens at `127.0.0.1:8080`. You can change this with the `--bind-addr` flag.
 
 To query the mesh info via the MCP server, you can use the `mcp-client` tool provided in the repository:
 
 ```bash
-./bin/mcp-client -socket /path/to/mcp.sock
+./bin/mcp-client -url http://127.0.0.1:8080/mcp/events
 ```
 
 ## Testing

--- a/api/constants.go
+++ b/api/constants.go
@@ -21,6 +21,8 @@ const MCPProtocolID protocol.ID = "/sam/mcp/1.0.0"
 const GossipEvents = "/sam/mesh/events/v1"
 const AuthProtocolID protocol.ID = "/sam/auth/1.0.0"
 
+const DefaultAudience = "sam-mesh-audience"
+
 // Biscuit fact names
 const (
 	FactExpiration    = "expiration"

--- a/cmd/mcp-client/main.go
+++ b/cmd/mcp-client/main.go
@@ -30,22 +30,17 @@ import (
 
 func main() {
 	serverURL := flag.String("url", "", "MCP server URL (e.g. http://localhost:8080/)")
-	toolName := flag.String("tool", "get_mesh_info", "Tool to call")
+	toolName := flag.String("tool", "", "Tool to call")
 	toolArgs := flag.String("args", "{}", "JSON arguments for the tool")
-	timoutArgs := flag.Int("timeout", 10, "Timeout in seconds")
+	timeoutArgs := flag.Int("timeout", 10, "Timeout in seconds")
+	listTools := flag.Bool("list", false, "List available tools and exit")
 	flag.Parse()
 
 	if *serverURL == "" {
 		log.Fatal("Must specify -url")
 	}
 
-	var ctx context.Context
-	var cancel context.CancelFunc
-	if timoutArgs != nil {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(*timoutArgs)*time.Second)
-	} else {
-		ctx = context.Background()
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*timeoutArgs)*time.Second)
 	defer cancel()
 
 	sigs := make(chan os.Signal, 1)
@@ -72,6 +67,17 @@ func main() {
 			log.Printf("Failed to close session: %v", err)
 		}
 	}()
+
+	if *listTools || *toolName == "" {
+		tools, err := session.ListTools(ctx, &mcp.ListToolsParams{})
+		if err != nil {
+			log.Fatalf("ListTools failed: %v", err)
+		}
+		for _, t := range tools.Tools {
+			fmt.Printf("%s\t%s\n", t.Name, t.Description)
+		}
+		return
+	}
 
 	var args map[string]any
 	if *toolArgs != "" {

--- a/cmd/sam-hub/hooks.go
+++ b/cmd/sam-hub/hooks.go
@@ -34,13 +34,11 @@ var _ connmgr.ConnectionGater = (*hubConnGate)(nil)
 type hubConnGate struct {
 	mu            sync.RWMutex
 	authenticated map[peer.ID]bool
-	pending       map[peer.ID]time.Time
 }
 
 func newHubConnGate() *hubConnGate {
 	return &hubConnGate{
 		authenticated: make(map[peer.ID]bool),
-		pending:       make(map[peer.ID]time.Time),
 	}
 }
 
@@ -50,11 +48,6 @@ func (g *hubConnGate) InterceptAddrDial(p peer.ID, m multiaddr.Multiaddr) bool {
 func (g *hubConnGate) InterceptAccept(c network.ConnMultiaddrs) bool           { return true }
 
 func (g *hubConnGate) InterceptSecured(dir network.Direction, p peer.ID, mas network.ConnMultiaddrs) bool {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if !g.authenticated[p] {
-		g.pending[p] = time.Now()
-	}
 	return true
 }
 
@@ -78,7 +71,6 @@ func (n *notifier) Disconnected(_ network.Network, c network.Conn) {
 	n.hub.gater.mu.Lock()
 	wasAuth := n.hub.gater.authenticated[p]
 	delete(n.hub.gater.authenticated, p)
-	delete(n.hub.gater.pending, p)
 	n.hub.gater.mu.Unlock()
 	
 	logger.Infow("Peer disconnected", "peer_id", p, "was_authenticated", wasAuth)

--- a/cmd/sam-hub/keyring.go
+++ b/cmd/sam-hub/keyring.go
@@ -192,6 +192,18 @@ func (kr *KeyRing) GetAllValidKeys() []ed25519.PrivateKey {
 	return keys
 }
 
+// GetAllValidPublicKeys returns all public keys that are still valid.
+func (kr *KeyRing) GetAllValidPublicKeys() []ed25519.PublicKey {
+	kr.mu.RLock()
+	defer kr.mu.RUnlock()
+
+	keys := []ed25519.PublicKey{ed25519.PublicKey(kr.Current.Public)}
+	for _, kp := range kr.Previous {
+		keys = append(keys, ed25519.PublicKey(kp.Public))
+	}
+	return keys
+}
+
 // Close closes the BoltDB database.
 func (kr *KeyRing) Close() error {
 	return kr.db.Close()

--- a/cmd/sam-hub/main.go
+++ b/cmd/sam-hub/main.go
@@ -135,8 +135,9 @@ func NewHub(ctx context.Context, policy *api.PolicyConfig) (*Hub, error) {
 		libp2p.Security(libp2ptls.ID, libp2ptls.New),
 		libp2p.EnableRelayService(),
 		libp2p.ConnectionGater(gater),
-		libp2p.EnableNATService(),
 		libp2p.ConnectionManager(cm),
+		libp2p.EnableAutoNATv2(),
+		libp2p.EnableNATService(),
 	)
 	if err != nil {
 		return nil, err
@@ -167,7 +168,10 @@ func NewHub(ctx context.Context, policy *api.PolicyConfig) (*Hub, error) {
 			tr := &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
-			client := &http.Client{Transport: tr}
+			client := &http.Client{
+				Timeout:   30 * time.Second,
+				Transport: tr,
+			}
 			providerCtx = oidc.ClientContext(ctx, client)
 		}
 		provider, err := oidc.NewProvider(providerCtx, iss)
@@ -229,89 +233,53 @@ func NewHub(ctx context.Context, policy *api.PolicyConfig) (*Hub, error) {
 	return hub, nil
 }
 
-func (h *Hub) handleEnroll(s network.Stream) {
+func (h *Hub) handleAuthHandshake(s network.Stream) {
 	defer func() {
-		_ = s.Close()
+		if err := s.Close(); err != nil {
+			logger.Errorf("[AuthN] Failed to close auth stream: %v", err)
+		}
 	}()
 	remotePeer := s.Conn().RemotePeer()
-
-	if !h.limiter.Allow() {
-		logger.Warnw("Rate limit exceeded during enrollment", "peer_id", remotePeer)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		_ = s.Reset()
-		return
-	}
-
-	logger.Infow("New enrollment request", "peer_id", remotePeer)
 
 	reader := msgio.NewVarintReaderSize(s, 1024*64)
 	msg, err := reader.ReadMsg()
 	if err != nil {
-		logger.Errorw("Failed to read enrollment message", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
+		logger.Errorf("[AuthN] Failed to read handshake from %s: %v", remotePeer, err)
 		return
 	}
 	defer reader.ReleaseMsg(msg)
 
-	var req api.EnrollRequest
-	if err := proto.Unmarshal(msg, &req); err != nil {
-		logger.Errorw("Failed to unmarshal enrollment request", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
+	var exchange api.AuthFrame
+	if err := proto.Unmarshal(msg, &exchange); err != nil {
+		logger.Warnf("[AuthN] Invalid protobuf from %s", remotePeer)
 		return
 	}
 
-	if req.PeerId != remotePeer.String() {
-		logger.Warnw("Peer ID mismatch in enrollment", "peer_id", remotePeer, "requested_peer_id", req.PeerId)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		h.sendEnrollResponse(s, nil, "Peer ID mismatch", 0, nil, nil)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), JWTVerificationTimeout)
-	defer cancel()
-	claims, token, err := h.parseAndVerifyJWT(ctx, req.Jwt, h.AllowedAudiences)
+	b, err := h.verifyBiscuit(exchange.Biscuit, remotePeer)
 	if err != nil {
-		logger.Errorw("JWT verification failed", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		h.sendEnrollResponse(s, nil, err.Error(), 0, nil, nil)
+		logger.Warnf("[AuthN] Authorization failed for %s: %v", remotePeer, err)
 		return
 	}
 
-	biscuitData, err := h.mintBiscuitToken(claims, token, remotePeer)
-	if err != nil {
-		logger.Errorw("Biscuit minting failed", "peer_id", remotePeer, "error", err)
-		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
-		h.sendEnrollResponse(s, nil, "Failed to mint biscuit", 0, nil, nil)
+	// Enforce hardware binding: token must include node(<remotePeerID>)
+	boundFact := biscuit.Fact{Predicate: biscuit.Predicate{
+		Name: "node",
+		IDs:  []biscuit.Term{biscuit.String(remotePeer.String())},
+	}}
+	if _, err := b.GetBlockID(boundFact); err != nil {
+		logger.Warnf("[AuthN] Token is not bound to peer %s", remotePeer)
 		return
 	}
 
+	logger.Infof("[AuthN] Successfully authenticated peer %s", remotePeer)
+
+	// Update active nodes gauge and gater state
 	h.gater.mu.Lock()
-	// Update active nodes gauge if this is a new node
 	if !h.gater.authenticated[remotePeer] {
 		samHubActiveNodes.Inc()
 	}
 	h.gater.authenticated[remotePeer] = true
-	delete(h.gater.pending, remotePeer)
-
-	// Collect authenticated peers
-	var authPeers []peer.ID
-	for p := range h.gater.authenticated {
-		authPeers = append(authPeers, p)
-	}
 	h.gater.mu.Unlock()
-
-	var knownPeers []string
-	for _, p := range authPeers {
-		knownPeers = append(knownPeers, p.String())
-	}
-
-	policies := []string{
-		`allow if operation($op)`,
-	}
-
-	h.sendEnrollResponse(s, biscuitData, "", token.Expiry.Unix(), knownPeers, policies)
-	logger.Infow("Successfully enrolled peer", "peer_id", remotePeer)
-	samHubEnrollmentTotal.WithLabelValues("success").Inc()
 
 	// Publish JOIN event
 	event := &api.MeshEvent{
@@ -334,43 +302,46 @@ func (h *Hub) handleEnroll(s network.Stream) {
 			}
 		}
 	}
+
+	// Send ACK back to client
+	writer := msgio.NewVarintWriter(s)
+	resp := &api.AuthResponse{Success: true}
+	respBytes, _ := proto.Marshal(resp)
+	if err := writer.WriteMsg(respBytes); err != nil {
+		logger.Errorf("[AuthN] Failed to write ACK to %s: %v", remotePeer, err)
+	}
 }
 
-func (h *Hub) sendEnrollResponse(s network.Stream, biscuitToken []byte, errMsg string, expiration int64, knownPeers []string, policies []string) {
-	var hubAddrs []string
-	if len(h.ExternalAddrs) > 0 {
-		for _, addr := range h.ExternalAddrs {
-			fullAddr := addr
-			if !strings.Contains(addr, "/p2p/") {
-				fullAddr = addr + "/p2p/" + h.Host.ID().String()
-			}
-			hubAddrs = append(hubAddrs, fullAddr)
-		}
-	} else {
-		for _, addr := range h.Host.Addrs() {
-			hubAddrs = append(hubAddrs, addr.String()+"/p2p/"+h.Host.ID().String())
-		}
-	}
-
-	pubKey := h.KeyRing.GetCurrentPublicKey()
-
-	resp := &api.EnrollResponse{
-		BiscuitToken: biscuitToken,
-		ErrorMessage: errMsg,
-		HubPublicKey: pubKey,
-		HubAddresses: hubAddrs,
-		Expiration:   expiration,
-		KnownPeers:   knownPeers,
-	}
-	data, err := proto.Marshal(resp)
+func (h *Hub) verifyBiscuit(biscuitData []byte, remotePeer peer.ID) (*biscuit.Biscuit, error) {
+	b, err := biscuit.Unmarshal(biscuitData)
 	if err != nil {
-		logger.Errorf("[Enroll] Failed to marshal response: %v", err)
-		return
+		return nil, fmt.Errorf("malformed biscuit: %w", err)
 	}
-	writer := msgio.NewVarintWriter(s)
-	if err := writer.WriteMsg(data); err != nil {
-		logger.Errorf("[Enroll] Failed to write response: %v", err)
+
+	keys := h.KeyRing.GetAllValidPublicKeys()
+	var lastErr error
+	for _, pubKey := range keys {
+		authorizer, err := b.Authorizer(pubKey)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		rule, err := parser.FromStringPolicy("allow if true")
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		authorizer.AddPolicy(rule)
+
+		if err := authorizer.Authorize(); err == nil {
+			return b, nil
+		} else {
+			lastErr = err
+		}
 	}
+
+	return nil, fmt.Errorf("no valid key found for verification: %v", lastErr)
 }
 
 func (h *Hub) parseAndVerifyJWT(ctx context.Context, jwtStr string, allowedAudiences []string) (jwt.MapClaims, *oidc.IDToken, error) {
@@ -538,31 +509,6 @@ func (h *Hub) mintBiscuitToken(claims jwt.MapClaims, token *oidc.IDToken, remote
 
 // startWatchdog periodically checks for peers that have connected but not completed OIDC
 // authentication within the grace period, and evicts them from the network.
-func (h *Hub) startWatchdog(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(10 * time.Second)
-		defer ticker.Stop()
-		for range ticker.C {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			h.gater.mu.Lock()
-			now := time.Now()
-			for pID, connectedAt := range h.gater.pending {
-				if now.Sub(connectedAt) > GracePeriod {
-					logger.Warnf("[Security] Evicting unauthenticated peer: %s", pID)
-					if err := h.Host.Network().ClosePeer(pID); err != nil {
-						logger.Errorf("[Security] Closing unauthenticated peer %s: %v", pID, err)
-					}
-					delete(h.gater.pending, pID)
-				}
-			}
-			h.gater.mu.Unlock()
-		}
-	}()
-}
 
 func (h *Hub) startRotation(ctx context.Context) {
 	if keyRotationInterval <= 0 {
@@ -672,13 +618,10 @@ func main() {
 			if err != nil {
 				logger.Fatal(err)
 			}
-			h.Host.SetStreamHandler(api.EnrollProtocolID, h.handleEnroll)
+			h.Host.SetStreamHandler(api.AuthProtocolID, h.handleAuthHandshake)
 
 			// Start key rotation if enabled
 			h.startRotation(ctx)
-
-			// Watchdog: Expel peers that connect but never finish authentication
-			h.startWatchdog(ctx)
 
 			startHTTPServer(h, bindAddress, adminToken, tlsCertFile, tlsKeyFile, tlsCAFile, &isHubReady)
 
@@ -757,6 +700,7 @@ func main() {
 			}
 
 			client := &http.Client{
+				Timeout: 30 * time.Second,
 				Transport: &http.Transport{
 					TLSClientConfig: tlsConfig,
 				},

--- a/cmd/sam-hub/main.go
+++ b/cmd/sam-hub/main.go
@@ -95,23 +95,25 @@ var (
 	tlsKeyFile            string
 	tlsCAFile             string
 	externalMultiaddrs    []string
+	allowedAudiencesFlag  string
 )
 
 var logger = golog.Logger("sam-hub")
 
 // Hub handles identity bridging and network discovery
 type Hub struct {
-	Host          host.Host
-	DHT           *dht.IpfsDHT
-	Providers     map[string]*oidc.Provider
-	KeyRing       *KeyRing
-	MeshID        string
-	PubSub        *pubsub.PubSub
-	EventTopic    *pubsub.Topic
-	gater         *hubConnGate
-	Policy        *api.PolicyConfig
-	limiter       *rate.Limiter
-	ExternalAddrs []string
+	Host             host.Host
+	DHT              *dht.IpfsDHT
+	Providers        map[string]*oidc.Provider
+	KeyRing          *KeyRing
+	MeshID           string
+	PubSub           *pubsub.PubSub
+	EventTopic       *pubsub.Topic
+	gater            *hubConnGate
+	Policy           *api.PolicyConfig
+	limiter          *rate.Limiter
+	ExternalAddrs    []string
+	AllowedAudiences []string
 }
 
 // NewHub starts a host supporting both QUIC and TCP (with TLS 1.3)
@@ -189,16 +191,28 @@ func NewHub(ctx context.Context, policy *api.PolicyConfig) (*Hub, error) {
 		return nil, fmt.Errorf("failed to create keyring: %w", err)
 	}
 
+	var auds []string
+	for _, aud := range strings.Split(allowedAudiencesFlag, ",") {
+		aud = strings.TrimSpace(aud)
+		if aud != "" {
+			auds = append(auds, aud)
+		}
+	}
+	if len(auds) == 0 {
+		auds = []string{api.DefaultAudience}
+	}
+
 	hub := &Hub{
-		Host:          h,
-		DHT:           kadDHT,
-		gater:         gater,
-		Providers:     providers,
-		KeyRing:       kr,
-		MeshID:        meshName,
-		Policy:        policy,
-		limiter:       rate.NewLimiter(rate.Limit(EnrollRateLimit), EnrollBurst),
-		ExternalAddrs: externalMultiaddrs,
+		Host:             h,
+		DHT:              kadDHT,
+		gater:            gater,
+		Providers:        providers,
+		KeyRing:          kr,
+		MeshID:           meshName,
+		Policy:           policy,
+		limiter:          rate.NewLimiter(rate.Limit(EnrollRateLimit), EnrollBurst),
+		ExternalAddrs:    externalMultiaddrs,
+		AllowedAudiences: auds,
 	}
 
 	h.Network().Notify(&notifier{hub: hub})
@@ -255,7 +269,7 @@ func (h *Hub) handleEnroll(s network.Stream) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), JWTVerificationTimeout)
 	defer cancel()
-	claims, token, err := h.parseAndVerifyJWT(ctx, req.Jwt)
+	claims, token, err := h.parseAndVerifyJWT(ctx, req.Jwt, h.AllowedAudiences)
 	if err != nil {
 		logger.Errorw("JWT verification failed", "peer_id", remotePeer, "error", err)
 		samHubEnrollmentTotal.WithLabelValues("failed").Inc()
@@ -359,18 +373,26 @@ func (h *Hub) sendEnrollResponse(s network.Stream, biscuitToken []byte, errMsg s
 	}
 }
 
-func (h *Hub) parseAndVerifyJWT(ctx context.Context, jwtStr string) (jwt.MapClaims, *oidc.IDToken, error) {
+func (h *Hub) parseAndVerifyJWT(ctx context.Context, jwtStr string, allowedAudiences []string) (jwt.MapClaims, *oidc.IDToken, error) {
 	jwtParser := jwt.Parser{}
 	jwtToken, _, err := jwtParser.ParseUnverified(jwtStr, jwt.MapClaims{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse JWT: %w", err)
 	}
+
+	// 1. Defend against downgrade attacks immediately
+	alg, ok := jwtToken.Header["alg"].(string)
+	if !ok || alg == "" || strings.ToLower(alg) == "none" {
+		return nil, nil, fmt.Errorf("invalid or missing alg header")
+	}
+
 	claims, ok := jwtToken.Claims.(jwt.MapClaims)
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid JWT claims")
 	}
 	iss, _ := claims["iss"].(string)
 
+	// 2. Extract the audience
 	var aud string
 	switch a := claims["aud"].(type) {
 	case string:
@@ -385,25 +407,33 @@ func (h *Hub) parseAndVerifyJWT(ctx context.Context, jwtStr string) (jwt.MapClai
 		return nil, nil, fmt.Errorf("missing aud claim")
 	}
 
-	alg, ok := jwtToken.Header["alg"].(string)
-	if !ok || alg == "" {
-		return nil, nil, fmt.Errorf("missing alg header")
+	// 3. Verify the audience matches one of your expected tenants/platforms
+	validAudience := false
+	for _, allowed := range allowedAudiences {
+		if aud == allowed {
+			validAudience = true
+			break
+		}
+	}
+	if !validAudience {
+		return nil, nil, fmt.Errorf("untrusted audience: %s", aud)
 	}
 
+	// 4. Route to the correct provider
 	provider, ok := h.Providers[iss]
 	if !ok {
 		return nil, nil, fmt.Errorf("unknown issuer: %s", iss)
 	}
 
-	verifier := provider.Verifier(&oidc.Config{ClientID: clientID})
+	// 5. Verify cryptographic signature, bypassing the strict single-clientID check
+	// because we already validated the audience against our allowed list above.
+	verifier := provider.Verifier(&oidc.Config{
+		SkipClientIDCheck: true,
+	})
 
 	token, err := verifier.Verify(ctx, jwtStr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("JWT validation failed: %w", err)
-	}
-
-	if alg == "none" {
-		return nil, nil, fmt.Errorf("invalid alg claim")
 	}
 
 	return claims, token, nil
@@ -672,6 +702,7 @@ func main() {
 	rootCmd.Flags().StringSliceVar(&listenAddrs, "listen", []string{"/ip4/0.0.0.0/udp/8080/quic-v1", "/ip4/0.0.0.0/tcp/8080"}, "libp2p Listen Addrs")
 	rootCmd.Flags().StringSliceVar(&externalMultiaddrs, "external-multiaddr", []string{}, "External multiaddrs to announce")
 	rootCmd.Flags().StringVar(&meshName, "mesh", DefaultMeshName, "Mesh federation name")
+	rootCmd.Flags().StringVar(&allowedAudiencesFlag, "allowed-audiences", api.DefaultAudience, "Comma-separated list of allowed OIDC audiences")
 	rootCmd.Flags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS verification for OIDC issuers")
 	rootCmd.Flags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	rootCmd.Flags().StringVar(&policyFile, "policy-file", DefaultPolicyFile, "Path to policies.yaml")

--- a/cmd/sam-hub/server.go
+++ b/cmd/sam-hub/server.go
@@ -15,20 +15,27 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync/atomic"
 
+	"github.com/google/sam/api"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/protobuf/proto"
 )
 
 // startHTTPServer starts the HTTP/HTTPS server for metrics, healthz, and admin commands.
 func startHTTPServer(h *Hub, bindAddr string, adminToken string, tlsCertFile string, tlsKeyFile string, tlsCAFile string, isHubReady *atomic.Bool) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/register", handleRegisterHTTP(h))
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if isHubReady.Load() {
 			w.WriteHeader(http.StatusOK)
@@ -84,5 +91,118 @@ func startHTTPServer(h *Hub, bindAddr string, adminToken string, tlsCertFile str
 				logger.Errorf("HTTP server failed: %v", err)
 			}
 		}()
+	}
+}
+
+func handleRegisterHTTP(h *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read body", http.StatusBadRequest)
+			return
+		}
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				logger.Errorf("failed to close request body: %v", err)
+			}
+		}()
+
+		var req api.EnrollRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
+
+		if !h.limiter.Allow() {
+			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
+		logger.Infow("New HTTP enrollment request", "peer_id", req.PeerId)
+
+		ctx, cancel := context.WithTimeout(context.Background(), JWTVerificationTimeout)
+		defer cancel()
+
+		claims, token, err := h.parseAndVerifyJWT(ctx, req.Jwt, h.AllowedAudiences)
+		if err != nil {
+			logger.Errorw("JWT verification failed", "peer_id", req.PeerId, "error", err)
+			http.Error(w, "JWT validation failed: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		pID, err := peer.Decode(req.PeerId)
+		if err != nil {
+			logger.Errorw("Invalid Peer ID", "peer_id", req.PeerId, "error", err)
+			http.Error(w, "Invalid Peer ID", http.StatusBadRequest)
+			return
+		}
+
+		biscuitData, err := h.mintBiscuitToken(claims, token, pID)
+		if err != nil {
+			logger.Errorw("Biscuit minting failed", "peer_id", req.PeerId, "error", err)
+			http.Error(w, "Failed to mint biscuit", http.StatusInternalServerError)
+			return
+		}
+
+		h.gater.mu.Lock()
+		if !h.gater.authenticated[pID] {
+			samHubActiveNodes.Inc()
+		}
+		h.gater.authenticated[pID] = true
+		h.gater.mu.Unlock()
+
+		var authPeers []peer.ID
+		h.gater.mu.Lock()
+		for p := range h.gater.authenticated {
+			authPeers = append(authPeers, p)
+		}
+		h.gater.mu.Unlock()
+
+		var knownPeers []string
+		for _, p := range authPeers {
+			knownPeers = append(knownPeers, p.String())
+		}
+
+		var hubAddrs []string
+		if len(h.ExternalAddrs) > 0 {
+			for _, addr := range h.ExternalAddrs {
+				fullAddr := addr
+				if !strings.Contains(addr, "/p2p/") {
+					fullAddr = addr + "/p2p/" + h.Host.ID().String()
+				}
+				hubAddrs = append(hubAddrs, fullAddr)
+			}
+		} else {
+			for _, addr := range h.Host.Addrs() {
+				hubAddrs = append(hubAddrs, addr.String()+"/p2p/"+h.Host.ID().String())
+			}
+		}
+
+		resp := &api.EnrollResponse{
+			BiscuitToken: biscuitData,
+			HubPublicKey: h.KeyRing.GetCurrentPublicKey(),
+			HubAddresses: hubAddrs,
+			Expiration:   token.Expiry.Unix(),
+			KnownPeers:   knownPeers,
+		}
+
+		respData, err := proto.Marshal(resp)
+		if err != nil {
+			logger.Errorf("[Enroll] Failed to marshal response: %v", err)
+			http.Error(w, "Failed to serialize response", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respData)
+
+		logger.Infow("Successfully enrolled peer via HTTP", "peer_id", req.PeerId)
+		samHubEnrollmentTotal.WithLabelValues("success").Inc()
 	}
 }

--- a/cmd/sam-hub/server.go
+++ b/cmd/sam-hub/server.go
@@ -21,13 +21,14 @@ import (
 	"os"
 	"sync/atomic"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // startHTTPServer starts the HTTP/HTTPS server for metrics, healthz, and admin commands.
 func startHTTPServer(h *Hub, bindAddr string, adminToken string, tlsCertFile string, tlsKeyFile string, tlsCAFile string, isHubReady *atomic.Bool) {
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}))
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if isHubReady.Load() {
 			w.WriteHeader(http.StatusOK)

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -39,7 +39,7 @@ const (
 	DefaultMeshName          = "public-mesh"
 	DefaultDiscoveryInterval = "2s"
 	DefaultHubURL            = "http://localhost:8080"
-	DefaultConfigFile   = "sam-node.yaml"
+	DefaultConfigFile        = "sam-node.yaml"
 
 	// Renewal timing defaults
 	DefaultRenewalFallback = 50 * time.Minute
@@ -56,13 +56,15 @@ var (
 	clientIDFlag          string
 	clientSecretFlag      string
 	tokenURLFlag          string
+	deviceAuthURLFlag     string
+	audienceFlag          string
 	hubPublicKeyFlag      string
 	bindAddrFlag          string
 	meshFlag              string
 	discoveryIntervalFlag string
 	enableRelayFlag       bool
 	logLevelFlag          string
-	configFile       string
+	configFile            string
 	keyGracePeriodFlag    time.Duration
 
 	apiTokenFlag string
@@ -161,7 +163,7 @@ func main() {
 				if len(token) == 0 {
 					logger.Fatal("No JWT or stored identity found. Cannot authenticate.")
 				}
-				fmt.Println("Using stored identity.")
+				logger.Infoln("Using stored identity.")
 
 				if len(hubPubKey) == 0 {
 					logger.Fatal("Hub public key not found in store and not provided. Cannot verify peers.")
@@ -172,6 +174,7 @@ func main() {
 					logger.Fatalf("Failed to start mesh node: %v", err)
 				}
 			} else {
+				// We have a new JWT (from flag or interactive login), need to enroll
 				var initHubAddrs []multiaddr.Multiaddr
 				ma, err := multiaddr.NewMultiaddr(hubAddr)
 				if err == nil {
@@ -256,12 +259,20 @@ func main() {
 				}
 			}()
 
-			if tokenURLFlag == "" {
-				logger.Fatal("--token-url is required for login")
-			}
-
 			dummyNode := &SamNode{Store: store}
-			jwtStr, err := dummyNode.InteractiveLogin(ctx, tokenURLFlag)
+			deviceAuthURL := deviceAuthURLFlag
+			if deviceAuthURL == "" {
+				deviceAuthURL = "https://oauth2.googleapis.com/device/code"
+			}
+			tokenURL := tokenURLFlag
+			if tokenURL == "" {
+				tokenURL = "https://oauth2.googleapis.com/token"
+			}
+			clientID := clientIDFlag
+			if clientID == "" {
+				clientID = api.DefaultAudience
+			}
+			jwtStr, err := dummyNode.InteractiveLogin(ctx, deviceAuthURL, tokenURL, clientID, audienceFlag)
 			if err != nil {
 				logger.Fatalf("Failed to get token: %v", err)
 			}
@@ -322,6 +333,8 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&hubAddr, "hub", DefaultHubURL, "Hub URL")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", DefaultConfigFile, "Path to sam-node.yaml configuration file")
 	rootCmd.PersistentFlags().StringVar(&tokenURLFlag, "token-url", "", "OIDC Token URL")
+	rootCmd.PersistentFlags().StringVar(&deviceAuthURLFlag, "device-auth-url", "", "OIDC Device Authorization URL")
+	rootCmd.PersistentFlags().StringVar(&audienceFlag, "audience", api.DefaultAudience, "OIDC Audience")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(loginCmd)

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -15,11 +15,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -29,7 +32,6 @@ import (
 	"github.com/google/sam/api"
 	golog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-msgio"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
@@ -55,7 +57,7 @@ var (
 	jwtPathFlag           string
 	clientIDFlag          string
 	clientSecretFlag      string
-	tokenURLFlag          string
+	oidcIssuerFlag        string
 	deviceAuthURLFlag     string
 	audienceFlag          string
 	hubPublicKeyFlag      string
@@ -148,11 +150,15 @@ func main() {
 					logger.Fatalf("Failed to read JWT file: %v", err)
 				}
 				jwtStr = strings.TrimSpace(string(data))
-			} else if tokenURLFlag != "" {
-				logger.Info("Fetching JWT via OIDC Client Credentials...")
+			} else if oidcIssuerFlag != "" {
+				logger.Info("Discovering OIDC endpoints...")
 				dummyNode := &SamNode{}
-				var err error
-				jwtStr, err = dummyNode.FetchJWT(context.Background(), tokenURLFlag, clientIDFlag, clientSecretFlag)
+				tokenURL, err := dummyNode.DiscoverTokenURL(context.Background(), oidcIssuerFlag)
+				if err != nil {
+					logger.Fatalf("Failed to discover OIDC endpoints: %v", err)
+				}
+				logger.Info("Fetching JWT via OIDC Client Credentials...")
+				jwtStr, err = dummyNode.FetchJWT(context.Background(), tokenURL, clientIDFlag, clientSecretFlag)
 				if err != nil {
 					logger.Fatalf("Failed to fetch JWT: %v", err)
 				}
@@ -176,26 +182,28 @@ func main() {
 			} else {
 				// We have a new JWT (from flag or interactive login), need to enroll
 				var initHubAddrs []multiaddr.Multiaddr
-				ma, err := multiaddr.NewMultiaddr(hubAddr)
-				if err == nil {
-					initHubAddrs = []multiaddr.Multiaddr{ma}
-				} else {
-					// Try parsing as host:port
-					host, port, err := net.SplitHostPort(hubAddr)
+				if !strings.HasPrefix(hubAddr, "http://") && !strings.HasPrefix(hubAddr, "https://") {
+					ma, err := multiaddr.NewMultiaddr(hubAddr)
 					if err == nil {
-						ip := net.ParseIP(host)
-						var maddr multiaddr.Multiaddr
-						if ip != nil {
-							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
-						} else {
-							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
-						}
-						initHubAddrs = []multiaddr.Multiaddr{maddr}
+						initHubAddrs = []multiaddr.Multiaddr{ma}
 					} else {
-						if len(hubAddrs) > 0 {
-							initHubAddrs = hubAddrs
+						// Try parsing as host:port
+						host, port, err := net.SplitHostPort(hubAddr)
+						if err == nil {
+							ip := net.ParseIP(host)
+							var maddr multiaddr.Multiaddr
+							if ip != nil {
+								maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
+							} else {
+								maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
+							}
+							initHubAddrs = []multiaddr.Multiaddr{maddr}
 						} else {
-							logger.Fatalf("Invalid hub address and no stored config: %v. You can use community maintained meshes like hub.sam-mesh.dev (Production) or bananas.sam-mesh.dev (Testnet)", err)
+							if len(hubAddrs) > 0 {
+								initHubAddrs = hubAddrs
+							} else {
+								logger.Fatalf("Invalid hub address and no stored config: %v. You can use community maintained meshes like hub.sam-mesh.dev (Production) or bananas.sam-mesh.dev (Testnet)", err)
+							}
 						}
 					}
 				}
@@ -220,7 +228,7 @@ func main() {
 			}
 
 			// Start renewal loop
-			node.StartRenewalLoop(ctx, tokenURLFlag, clientIDFlag, clientSecretFlag, jwtPathFlag)
+			node.StartRenewalLoop(ctx, oidcIssuerFlag, clientIDFlag, clientSecretFlag, jwtPathFlag)
 
 			node.Host.SetStreamHandler(api.AuthProtocolID, node.HandleAuthHandshake)
 
@@ -261,10 +269,20 @@ func main() {
 
 			dummyNode := &SamNode{Store: store}
 			deviceAuthURL := deviceAuthURLFlag
+			tokenURL := ""
+
+			if oidcIssuerFlag != "" {
+				logger.Info("Discovering OIDC endpoints...")
+				var err error
+				tokenURL, deviceAuthURL, err = dummyNode.DiscoverEndpoints(context.Background(), oidcIssuerFlag)
+				if err != nil {
+					logger.Fatalf("Failed to discover OIDC endpoints: %v", err)
+				}
+			}
+
 			if deviceAuthURL == "" {
 				deviceAuthURL = "https://oauth2.googleapis.com/device/code"
 			}
-			tokenURL := tokenURLFlag
 			if tokenURL == "" {
 				tokenURL = "https://oauth2.googleapis.com/token"
 			}
@@ -279,22 +297,24 @@ func main() {
 
 			// Connect to Hub and Enroll
 			var initHubAddrs []multiaddr.Multiaddr
-			ma, err := multiaddr.NewMultiaddr(hubAddr)
-			if err == nil {
-				initHubAddrs = []multiaddr.Multiaddr{ma}
-			} else {
-				host, port, err := net.SplitHostPort(hubAddr)
+			if !strings.HasPrefix(hubAddr, "http://") && !strings.HasPrefix(hubAddr, "https://") {
+				ma, err := multiaddr.NewMultiaddr(hubAddr)
 				if err == nil {
-					ip := net.ParseIP(host)
-					var maddr multiaddr.Multiaddr
-					if ip != nil {
-						maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
-					} else {
-						maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
-					}
-					initHubAddrs = []multiaddr.Multiaddr{maddr}
+					initHubAddrs = []multiaddr.Multiaddr{ma}
 				} else {
-					logger.Fatalf("Invalid hub address: %v", err)
+					host, port, err := net.SplitHostPort(hubAddr)
+					if err == nil {
+						ip := net.ParseIP(host)
+						var maddr multiaddr.Multiaddr
+						if ip != nil {
+							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", host, port))
+						} else {
+							maddr, _ = multiaddr.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%s", host, port))
+						}
+						initHubAddrs = []multiaddr.Multiaddr{maddr}
+					} else {
+						logger.Fatalf("Invalid hub address: %v", err)
+					}
 				}
 			}
 
@@ -332,7 +352,7 @@ func main() {
 	runCmd.Flags().StringVar(&tlsCAFlag, "tls-ca", "", "Path to TLS CA for sidecar API mTLS")
 	rootCmd.PersistentFlags().StringVar(&hubAddr, "hub", DefaultHubURL, "Hub URL")
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", DefaultConfigFile, "Path to sam-node.yaml configuration file")
-	rootCmd.PersistentFlags().StringVar(&tokenURLFlag, "token-url", "", "OIDC Token URL")
+	rootCmd.PersistentFlags().StringVar(&oidcIssuerFlag, "oidc-issuer", "", "OIDC Issuer URL")
 	rootCmd.PersistentFlags().StringVar(&deviceAuthURLFlag, "device-auth-url", "", "OIDC Device Authorization URL")
 	rootCmd.PersistentFlags().StringVar(&audienceFlag, "audience", api.DefaultAudience, "OIDC Audience")
 
@@ -377,16 +397,6 @@ func getOrGenerateKey(s *Store) crypto.PrivKey {
 	return priv
 }
 func (n *SamNode) Enroll(ctx context.Context, jwt string) error {
-	if n.HubPeerID == "" {
-		return fmt.Errorf("not connected to any hub")
-	}
-
-	s, err := n.Host.NewStream(ctx, n.HubPeerID, api.EnrollProtocolID)
-	if err != nil {
-		return fmt.Errorf("failed to open enroll stream: %v", err)
-	}
-	defer func() { _ = s.Close() }()
-
 	req := &api.EnrollRequest{
 		Jwt:    jwt,
 		PeerId: n.Host.ID().String(),
@@ -396,55 +406,92 @@ func (n *SamNode) Enroll(ctx context.Context, jwt string) error {
 		return fmt.Errorf("failed to marshal enroll request: %v", err)
 	}
 
-	writer := msgio.NewVarintWriter(s)
-	if err := writer.WriteMsg(data); err != nil {
-		return fmt.Errorf("failed to write enroll request: %v", err)
+	if !strings.HasPrefix(hubAddr, "http://") && !strings.HasPrefix(hubAddr, "https://") {
+		return fmt.Errorf("hub address must be an HTTP or HTTPS URL for enrollment: %s", hubAddr)
 	}
+	url := hubAddr + "/register"
+	logger.Infof("Enrolling via HTTP at %s", url)
 
-	reader := msgio.NewVarintReaderSize(s, 1024*64)
-	respMsg, err := reader.ReadMsg()
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("failed to read enroll response: %v", err)
+		return fmt.Errorf("failed to create HTTP request: %v", err)
 	}
-	defer reader.ReleaseMsg(respMsg)
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 
-	var resp api.EnrollResponse
-	if err := proto.Unmarshal(respMsg, &resp); err != nil {
-		return fmt.Errorf("failed to unmarshal enroll response: %v", err)
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Errorf("failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("enrollment failed with status %s: %s", resp.Status, string(body))
 	}
 
-	if resp.ErrorMessage != "" {
-		return fmt.Errorf("enrollment failed: %s", resp.ErrorMessage)
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	if len(resp.BiscuitToken) == 0 {
+	var enrollResp api.EnrollResponse
+	if err := proto.Unmarshal(respData, &enrollResp); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	if enrollResp.ErrorMessage != "" {
+		return fmt.Errorf("enrollment failed: %s", enrollResp.ErrorMessage)
+	}
+
+	if len(enrollResp.BiscuitToken) == 0 {
 		return fmt.Errorf("received empty biscuit token")
 	}
 
-	if err := n.Store.SaveIdentity(resp.BiscuitToken); err != nil {
+	if err := n.Store.SaveIdentity(enrollResp.BiscuitToken); err != nil {
 		return fmt.Errorf("failed to save identity: %v", err)
 	}
 
-	if err := n.Store.SaveIdentityExpiration(resp.Expiration); err != nil {
+	if err := n.Store.SaveIdentityExpiration(enrollResp.Expiration); err != nil {
 		return fmt.Errorf("failed to save identity expiration: %v", err)
 	}
 
-	if err := n.Store.SaveHubConfig(resp.HubPublicKey, resp.HubAddresses); err != nil {
+	if err := n.Store.SaveHubConfig(enrollResp.HubPublicKey, enrollResp.HubAddresses); err != nil {
 		return fmt.Errorf("failed to save hub config: %v", err)
 	}
 
 	n.keysMu.Lock()
-	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(resp.HubPublicKey), ReceivedAt: time.Now()})
+	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(enrollResp.HubPublicKey), ReceivedAt: time.Now()})
 	n.keysMu.Unlock()
 
 	// Add known peers from response
 	n.mu.Lock()
-	for _, p := range resp.KnownPeers {
+	for _, p := range enrollResp.KnownPeers {
 		n.knownPeers[p] = true
 		fmt.Printf("[Enroll] Added known peer from hub: %s\n", p)
 	}
 	n.mu.Unlock()
 
-	fmt.Println("Successfully enrolled and stored identity and hub config.")
+	// Connect and Auth to hub after enrollment to join the mesh
+	for _, addrStr := range enrollResp.HubAddresses {
+		addr, err := multiaddr.NewMultiaddr(addrStr)
+		if err != nil {
+			logger.Warnf("Failed to parse hub address from response: %v", err)
+			continue
+		}
+		if err := n.ConnectAndAuthWithHub(ctx, addr); err != nil {
+			logger.Warnf("Failed to connect and auth with hub after enrollment: %v", err)
+		} else {
+			break
+		}
+	}
+
+	fmt.Println("Successfully enrolled via HTTP and stored identity and hub config.")
 	return nil
 }

--- a/cmd/sam-node/middleware.go
+++ b/cmd/sam-node/middleware.go
@@ -149,10 +149,15 @@ func (n *SamNode) WithBiscuitAuth(next network.StreamHandler) network.StreamHand
 			var jwtStr string
 			var err error
 
-			if tokenURLFlag != "" {
-				jwtStr, err = n.FetchJWT(context.Background(), tokenURLFlag, clientIDFlag, clientSecretFlag)
+			if oidcIssuerFlag != "" {
+				tokenURL, err := n.DiscoverTokenURL(context.Background(), oidcIssuerFlag)
 				if err != nil {
-					logger.Errorf("[Auth] Failed to fetch JWT for fallback: %v", err)
+					logger.Errorf("[Auth] Failed to discover OIDC endpoints for fallback: %v", err)
+				} else {
+					jwtStr, err = n.FetchJWT(context.Background(), tokenURL, clientIDFlag, clientSecretFlag)
+					if err != nil {
+						logger.Errorf("[Auth] Failed to fetch JWT for fallback: %v", err)
+					}
 				}
 			} else if jwtPathFlag != "" {
 				data, err := os.ReadFile(jwtPathFlag)

--- a/cmd/sam-node/node.go
+++ b/cmd/sam-node/node.go
@@ -191,32 +191,11 @@ func NewSamNode(ctx context.Context, privKey crypto.PrivKey, hubPubKey ed25519.P
 		return nil, fmt.Errorf("failed to bootstrap DHT: %w", err)
 	}
 
-	// Bootstrap: Connect to the Hub
+	// Bootstrap: Connect and Auth to the Hub
 	for _, addr := range hubAddrs {
-		addrInfo, err := peer.AddrInfoFromP2pAddr(addr)
-		if err != nil || addrInfo == nil {
-			// Try to connect without Peer ID in address
-			addrInfo = &peer.AddrInfo{
-				Addrs: []multiaddr.Multiaddr{addr},
-			}
-			logger.Warn("[AuthN] Connecting to hub without Peer ID verification in address.")
-		}
-		if err := h.Connect(ctx, *addrInfo); err != nil {
-			logger.Warnf("[AuthN] Failed to bootstrap to hub %s: %v", addr, err)
+		if err := node.ConnectAndAuthWithHub(ctx, addr); err != nil {
+			logger.Warnf("[AuthN] Failed to bootstrap and auth with hub %s: %v", addr, err)
 		} else {
-			if addrInfo.ID == "" {
-				// Discover Peer ID from connection
-				for _, c := range h.Network().Conns() {
-					if c.RemoteMultiaddr().Equal(addr) {
-						node.HubPeerID = c.RemotePeer()
-						logger.Infof("[AuthN] Connected to hub (discovered PeerID): %s", node.HubPeerID)
-						break
-					}
-				}
-			} else {
-				node.HubPeerID = addrInfo.ID
-				logger.Infof("[AuthN] Connected to hub: %s", addrInfo.ID)
-			}
 			break
 		}
 	}
@@ -301,7 +280,70 @@ func NewSamNode(ctx context.Context, privKey crypto.PrivKey, hubPubKey ed25519.P
 	return node, nil
 }
 
-func (n *SamNode) StartRenewalLoop(ctx context.Context, tokenURL, clientID, clientSecret, jwtPath string) {
+func (n *SamNode) ConnectAndAuthWithHub(ctx context.Context, addr multiaddr.Multiaddr) error {
+	addrInfo, err := peer.AddrInfoFromP2pAddr(addr)
+	if err != nil {
+		return fmt.Errorf("failed to get AddrInfo from multiaddr: %w", err)
+	}
+
+	if err := n.Host.Connect(ctx, *addrInfo); err != nil {
+		return fmt.Errorf("failed to connect to hub %s: %w", addr, err)
+	}
+
+	n.HubPeerID = addrInfo.ID
+	logger.Infof("[AuthN] Connected to hub: %s", addrInfo.ID)
+
+	// Load biscuit from store
+	biscuitBytes, err := n.Store.LoadIdentity()
+	if err != nil {
+		return fmt.Errorf("failed to load identity from store: %w", err)
+	}
+	if len(biscuitBytes) == 0 {
+		return fmt.Errorf("no identity biscuit found in store")
+	}
+
+	// Open auth stream
+	s, err := n.Host.NewStream(ctx, addrInfo.ID, api.AuthProtocolID)
+	if err != nil {
+		return fmt.Errorf("failed to open auth stream to hub: %w", err)
+	}
+	defer func() {
+		if err := s.Close(); err != nil {
+			logger.Errorf("failed to close stream: %v", err)
+		}
+	}()
+
+	writer := msgio.NewVarintWriter(s)
+	authFrame := &api.AuthFrame{Biscuit: biscuitBytes}
+	data, err := proto.Marshal(authFrame)
+	if err != nil {
+		return fmt.Errorf("failed to marshal auth frame: %w", err)
+	}
+	if err := writer.WriteMsg(data); err != nil {
+		return fmt.Errorf("failed to write auth frame: %w", err)
+	}
+
+	reader := msgio.NewVarintReaderSize(s, 1024*64)
+	respMsg, err := reader.ReadMsg()
+	if err != nil {
+		return fmt.Errorf("failed to read auth response: %w", err)
+	}
+	defer reader.ReleaseMsg(respMsg)
+
+	var resp api.AuthResponse
+	if err := proto.Unmarshal(respMsg, &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal auth response: %w", err)
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("auth failed: %s", resp.Error)
+	}
+
+	logger.Infof("[AuthN] Successfully authenticated with hub via libp2p")
+	return nil
+}
+
+func (n *SamNode) StartRenewalLoop(ctx context.Context, issuerURL, clientID, clientSecret, jwtPath string) {
 	go func() {
 		for {
 			var renewAfter = DefaultRenewalFallback // Default fallback
@@ -329,8 +371,12 @@ func (n *SamNode) StartRenewalLoop(ctx context.Context, tokenURL, clientID, clie
 			case <-timer.C:
 				fmt.Println("Renewing enrollment...")
 				var newJWT string
-				if tokenURL != "" {
-					var err error
+				if issuerURL != "" {
+					tokenURL, err := n.DiscoverTokenURL(ctx, issuerURL)
+					if err != nil {
+						fmt.Printf("Failed to discover OIDC endpoints for renewal: %v\n", err)
+						continue
+					}
 					newJWT, err = n.FetchJWT(ctx, tokenURL, clientID, clientSecret)
 					if err != nil {
 						fmt.Printf("Failed to fetch JWT for renewal: %v\n", err)

--- a/cmd/sam-node/oidc.go
+++ b/cmd/sam-node/oidc.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -177,4 +178,38 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, deviceAuthURL, tokenURL,
 			}
 		}
 	}
+}
+
+// DiscoverTokenURL discovers the token URL from the OIDC issuer.
+func (n *SamNode) DiscoverTokenURL(ctx context.Context, issuerURL string) (string, error) {
+	provider, err := oidc.NewProvider(ctx, issuerURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to create OIDC provider: %w", err)
+	}
+	var claims struct {
+		TokenURL string `json:"token_endpoint"`
+	}
+	if err := provider.Claims(&claims); err != nil {
+		return "", fmt.Errorf("failed to extract claims: %w", err)
+	}
+	if claims.TokenURL == "" {
+		return "", fmt.Errorf("token_endpoint not found in discovery document")
+	}
+	return claims.TokenURL, nil
+}
+
+// DiscoverEndpoints discovers both token and device auth endpoints.
+func (n *SamNode) DiscoverEndpoints(ctx context.Context, issuerURL string) (tokenURL, deviceURL string, err error) {
+	provider, err := oidc.NewProvider(ctx, issuerURL)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create OIDC provider: %w", err)
+	}
+	var claims struct {
+		TokenURL  string `json:"token_endpoint"`
+		DeviceURL string `json:"device_authorization_endpoint"`
+	}
+	if err := provider.Claims(&claims); err != nil {
+		return "", "", fmt.Errorf("failed to extract claims: %w", err)
+	}
+	return claims.TokenURL, claims.DeviceURL, nil
 }

--- a/cmd/sam-node/oidc.go
+++ b/cmd/sam-node/oidc.go
@@ -15,11 +15,14 @@
 package main
 
 import (
-	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
-	"os"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -38,27 +41,140 @@ func (n *SamNode) FetchJWT(ctx context.Context, tokenURL, clientID, clientSecret
 	return token.AccessToken, nil
 }
 
-// InteractiveLogin prompts the user to go to a URL and paste the token back.
-func (n *SamNode) InteractiveLogin(ctx context.Context, tokenURL string) (string, error) {
+// InteractiveLogin prompts the user to go to a URL and enter a code.
+func (n *SamNode) InteractiveLogin(ctx context.Context, deviceAuthURL, tokenURL, clientID, audience string) (string, error) {
+	if deviceAuthURL == "" {
+		return "", fmt.Errorf("device authorization URL is required")
+	}
+	if tokenURL == "" {
+		return "", fmt.Errorf("token URL is required")
+	}
+	if clientID == "" {
+		return "", fmt.Errorf("client ID is required for device flow")
+	}
+
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("scope", "openid email profile")
+	if audience != "" {
+		data.Set("audience", audience)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", deviceAuthURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Errorf("Failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("device auth request failed: %s - %s", resp.Status, string(body))
+	}
+
+	var authResp struct {
+		DeviceCode      string `json:"device_code"`
+		UserCode        string `json:"user_code"`
+		VerificationURI string `json:"verification_uri"`
+		ExpiresIn       int    `json:"expires_in"`
+		Interval        int    `json:"interval"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
+		return "", err
+	}
+
 	fmt.Println("------------------------------------------------------------")
 	fmt.Println("Device Authorization Flow")
 	fmt.Println("------------------------------------------------------------")
 	fmt.Printf("To authenticate, please go to the following URL in your browser:\n\n")
-	fmt.Printf("  %s\n\n", tokenURL)
-	fmt.Println("After successful login, copy the token and paste it below.")
+	fmt.Printf("  %s\n\n", authResp.VerificationURI)
+	fmt.Printf("And enter the following code:\n\n")
+	fmt.Printf("  %s\n\n", authResp.UserCode)
+	fmt.Println("Waiting for authorization...")
 	fmt.Println("------------------------------------------------------------")
-	fmt.Print("Enter JWT Token: ")
 
-	reader := bufio.NewReader(os.Stdin)
-	token, err := reader.ReadString('\n')
-	if err != nil {
-		return "", fmt.Errorf("failed to read token: %v", err)
+	interval := authResp.Interval
+	if interval <= 0 {
+		interval = 5
 	}
 
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return "", fmt.Errorf("empty token provided")
-	}
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	defer ticker.Stop()
 
-	return token, nil
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+			pollData := url.Values{}
+			pollData.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+			pollData.Set("device_code", authResp.DeviceCode)
+			pollData.Set("client_id", clientID)
+
+			req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(pollData.Encode()))
+			if err != nil {
+				return "", err
+			}
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			resp, err := client.Do(req)
+			if err != nil {
+				return "", err
+			}
+
+			if resp.StatusCode == http.StatusOK {
+				var tokenResp struct {
+					AccessToken string `json:"access_token"`
+					IdToken     string `json:"id_token"`
+				}
+				err := json.NewDecoder(resp.Body).Decode(&tokenResp)
+				if closeErr := resp.Body.Close(); closeErr != nil {
+					logger.Errorf("Failed to close response body: %v", closeErr)
+				}
+				if err != nil {
+					return "", err
+				}
+				if tokenResp.IdToken != "" {
+					return tokenResp.IdToken, nil
+				}
+				return tokenResp.AccessToken, nil
+			}
+
+			var errResp struct {
+				Error string `json:"error"`
+			}
+			err = json.NewDecoder(resp.Body).Decode(&errResp)
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				logger.Errorf("Failed to close response body: %v", closeErr)
+			}
+			if err != nil {
+				return "", fmt.Errorf("token request failed with status %s", resp.Status)
+			}
+
+			switch errResp.Error {
+			case "authorization_pending":
+				continue
+			case "slow_down":
+				ticker.Reset(time.Duration(interval+5) * time.Second)
+				continue
+			case "expired_token":
+				return "", fmt.Errorf("device code expired")
+			case "access_denied":
+				return "", fmt.Errorf("access denied by user")
+			default:
+				return "", fmt.Errorf("token request failed: %s", errResp.Error)
+			}
+		}
+	}
 }

--- a/cmd/sam-node/oidc_test.go
+++ b/cmd/sam-node/oidc_test.go
@@ -92,3 +92,35 @@ func TestInteractiveLogin(t *testing.T) {
 		t.Errorf("Expected token 'id_token_abc', got '%s'", res.token)
 	}
 }
+
+func TestDiscoverEndpoints(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                        "http://" + r.Host,
+			"token_endpoint":                "http://" + r.Host + "/token",
+			"device_authorization_endpoint": "http://" + r.Host + "/device/code",
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{}
+	ctx := context.Background()
+
+	tokenURL, deviceURL, err := node.DiscoverEndpoints(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("DiscoverEndpoints failed: %v", err)
+	}
+
+	if tokenURL != server.URL+"/token" {
+		t.Errorf("Expected tokenURL %s, got %s", server.URL+"/token", tokenURL)
+	}
+	if deviceURL != server.URL+"/device/code" {
+		t.Errorf("Expected deviceURL %s, got %s", server.URL+"/device/code", deviceURL)
+	}
+}

--- a/cmd/sam-node/oidc_test.go
+++ b/cmd/sam-node/oidc_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestInteractiveLogin(t *testing.T) {
+	// Mock OIDC server
+	mux := http.NewServeMux()
+
+	// State for polling
+	var authorized atomic.Bool
+
+	mux.HandleFunc("/device/code", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_code":      "dev_code_123",
+			"user_code":        "ABCD-1234",
+			"verification_uri": "http://example.com/verify",
+			"expires_in":       60,
+			"interval":         1, // Fast polling for test
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		if !authorized.Load() {
+			w.WriteHeader(http.StatusBadRequest)
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"error": "authorization_pending",
+			}); err != nil {
+				t.Errorf("Failed to encode response: %v", err)
+			}
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"access_token": "access_token_xyz",
+			"id_token":     "id_token_abc",
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Run InteractiveLogin in a goroutine because it blocks
+	type result struct {
+		token string
+		err   error
+	}
+	resChan := make(chan result, 1)
+
+	go func() {
+		token, err := node.InteractiveLogin(ctx, server.URL+"/device/code", server.URL+"/token", "client_id_test", "sam-e2e")
+		resChan <- result{token, err}
+	}()
+
+	// Wait a bit and then authorize the user
+	time.Sleep(1500 * time.Millisecond)
+	authorized.Store(true)
+
+	res := <-resChan
+	if res.err != nil {
+		t.Fatalf("InteractiveLogin failed: %v", res.err)
+	}
+
+	if res.token != "id_token_abc" {
+		t.Errorf("Expected token 'id_token_abc', got '%s'", res.token)
+	}
+}

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-sam-mesh.dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ The documentation here is intentionally small and aligned with what is implement
 3. Persist identity in local node store
 4. Run long-lived hub and node processes
 5. Run local and containerized BATS tests
-6. Expose local tools and mesh info via MCP server on a Unix socket
+6. Expose local tools and mesh info via MCP server over HTTP SSE
 7. Automated peer discovery via DHT and GossipSub events
 
 ## Start Here

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,6 @@
 - [Overview](#/README.md)
 - [Quick Start](#/quickstart.md)
+- [Agent Integration](#/agent_integration.md)
 - [CLI Reference](#/cli/reference.md)
 - [Testing](#/testing.md)
 - [License](https://github.com/aojea/sam/blob/main/LICENSE)

--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -1,0 +1,78 @@
+# Agent Integration Guide
+
+SAM is designed to be the networking layer for autonomous AI agents. The easiest way for your agent to interact with the mesh is through the **Model Context Protocol (MCP)** exposed locally by your node.
+
+Every `sam-node` runs a local MCP server that allows agents to:
+- Discover tools available on the mesh.
+- Connect to remote peers securely.
+- Query mesh information (e.g. `get_mesh_info`).
+- Call tools remotely (via `call_remote_tool`).
+
+## Connecting via MCP
+
+The `sam-node` exposes the MCP server over HTTP Server-Sent Events (SSE). By default, it listens at `127.0.0.1:8080`.
+
+The repository provides a Python SDK (`sam-mcp-python`) which implements the MCP client.
+
+### Prerequisites
+
+You need the `sam_mcp` package installed. From the repo root, run:
+
+```bash
+pip install ./sam-mcp-python
+```
+
+### Python SDK Demo
+
+The following snippet demonstrates how to connect to the local node's MCP server, list the available tools, and call the `get_mesh_info` tool.
+
+```python
+import asyncio
+import os
+import sys
+from sam_mcp.client import SamClient
+
+async def main():
+    # Connect to the local SAM node's MCP SSE endpoint
+    # By default, sam-node listens at 127.0.0.1:8080
+    url = os.environ.get("SAM_MCP_URL", "http://127.0.0.1:8080/mcp/events")
+    print(f"Connecting to SAM Node at {url}")
+
+    try:
+        async with SamClient(server_url=url) as client:
+            # Discover available tools provided by the SAM node
+            tools = await client.get_tools()
+            print(f"Discovered {len(tools)} tools:")
+            for tool in tools:
+                print(f" - {tool['name']}: {tool['description']}")
+
+            # Call the get_mesh_info tool to get information about the mesh
+            print("\nCalling get_mesh_info tool...")
+            result = await client.call_tool("get_mesh_info", {})
+            print("Result:")
+            print(result)
+
+    except Exception as e:
+        print(f"Error connecting to SAM Node: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+*(You can find this snippet at `docs/snippets/agent_demo.py`)*
+
+### Example Output
+
+When you run the demo while a `sam-node` is running locally, you'll see output similar to this:
+
+```
+Connecting to SAM Node at http://127.0.0.1:8080/mcp/events
+Discovered tools:
+ - get_mesh_info: Get information about the mesh network
+ - call_remote_tool: Call an MCP tool on a remote agent
+
+Calling get_mesh_info tool...
+Result:
+{'known_peers': [...], 'connected_peers': [...], 'dht_size': 1, 'hub_peer_id': '...'}
+```

--- a/docs/snippets/agent_demo.py
+++ b/docs/snippets/agent_demo.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+import sys
+from sam_mcp.client import SamClient
+
+async def main():
+    # Connect to the local SAM node's MCP SSE endpoint
+    # By default, sam-node listens at 127.0.0.1:8080
+    url = os.environ.get("SAM_MCP_URL", "http://127.0.0.1:8080/mcp/events")
+    print(f"Connecting to SAM Node at {url}")
+
+    try:
+        async with SamClient(server_url=url) as client:
+            # Discover available tools provided by the SAM node
+            tools = await client.get_tools()
+            print(f"Discovered {len(tools)} tools:")
+            for tool in tools:
+                print(f" - {tool['name']}: {tool['description']}")
+
+            # Call the get_mesh_info tool to get information about the mesh
+            print("\nCalling get_mesh_info tool...")
+            result = await client.call_tool("get_mesh_info", {})
+            print("Result:")
+            print(result)
+
+    except Exception as e:
+        print(f"Error connecting to SAM Node: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,12 @@ require (
 	github.com/ipfs/go-cid v0.6.1
 	github.com/ipfs/go-log/v2 v2.9.1
 	github.com/libp2p/go-libp2p v0.48.0
+	github.com/libp2p/go-libp2p-gostream v0.6.0
 	github.com/libp2p/go-libp2p-http v0.5.0
 	github.com/libp2p/go-libp2p-kad-dht v0.39.1
 	github.com/libp2p/go-libp2p-pubsub v0.16.0
 	github.com/libp2p/go-msgio v0.3.0
-	github.com/modelcontextprotocol/go-sdk v1.5.0
+	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/prometheus/client_golang v1.23.2
@@ -43,7 +44,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
@@ -60,7 +61,6 @@ require (
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.3.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.4.1 // indirect
-	github.com/libp2p/go-libp2p-gostream v0.6.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.8.0 // indirect
 	github.com/libp2p/go-libp2p-record v0.3.1 // indirect
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -338,8 +338,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
-github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
+github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
+github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -60,7 +60,7 @@ teardown() {
     -v "${data_vol}:/root/.config/sam-mesh" \
     -i \
     "sam-node:local" \
-    login --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" --token-url "http://mock-oidc:18080/token"
+    login --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" --token-url "http://mock-oidc:18080/token" --device-auth-url "http://mock-oidc:18080/device/code"
     
   # Now run the node with the stored identity
   docker run -d \

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -60,7 +60,7 @@ teardown() {
     -v "${data_vol}:/root/.config/sam-mesh" \
     -i \
     "sam-node:local" \
-    login --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" --token-url "http://mock-oidc:18080/token" --device-auth-url "http://mock-oidc:18080/device/code"
+    login --hub "http://sam-hub:9090" --oidc-issuer "http://mock-oidc:18080"
     
   # Now run the node with the stored identity
   docker run -d \
@@ -69,7 +69,7 @@ teardown() {
     -v "${data_vol}:/root/.config/sam-mesh" \
     "sam-node:local" \
     run \
-    --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}"
+    --hub "http://sam-hub:9090"
 
   mesh_wait_for_log "${node_name}" "Using stored identity." 20
   
@@ -110,7 +110,7 @@ teardown() {
     -v "${token_vol}:/var/run/secrets/tokens" \
     "sam-node:local" \
     run \
-    --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
+    --hub "http://sam-hub:9090" \
     --jwt-path "/var/run/secrets/tokens/sa-token"
 
   mesh_wait_for_log "${node_name}" "SAM Node Online" 20

--- a/tests/e2e/docker/mock_oidc.py
+++ b/tests/e2e/docker/mock_oidc.py
@@ -58,6 +58,7 @@ class Handler(BaseHTTPRequestHandler):
                 'issuer': 'http://mock-oidc:18080',
                 'authorization_endpoint': 'http://mock-oidc:18080/auth',
                 'token_endpoint': 'http://mock-oidc:18080/token',
+                'device_authorization_endpoint': 'http://mock-oidc:18080/device/code',
                 'jwks_uri': 'http://mock-oidc:18080/keys'
             }
             data = json.dumps(body).encode('utf-8')
@@ -80,10 +81,25 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(b'ok')
 
     def do_POST(self):
+        if self.path == '/device/code':
+            body = {
+                'device_code': 'dev_code_123',
+                'user_code': 'ABCD-1234',
+                'verification_uri': 'http://example.com/verify',
+                'expires_in': 60,
+                'interval': 1
+            }
+            data = json.dumps(body).encode('utf-8')
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
         if self.path == '/token':
             payload = {
                 'iss': 'http://mock-oidc:18080',
-                'aud': 'sam-e2e',
+                'aud': 'sam-mesh-audience',
                 'sub': 'test-user',
                 'exp': int(time.time()) + 3600,
                 'roles': ['admin', 'user']
@@ -91,6 +107,7 @@ class Handler(BaseHTTPRequestHandler):
             token = jwt.encode(payload, PRIVATE_KEY, algorithm='RS256', headers={'kid': 'test-key-id'})
             body = {
                 'access_token': token,
+                'id_token': token,
                 'token_type': 'Bearer',
                 'expires_in': 3600
             }

--- a/tests/e2e/docs_snippets.bats
+++ b/tests/e2e/docs_snippets.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load "lib/container_mesh.bash"
+
+setup() {
+  if ! mesh_require_docker; then
+    skip "docker not available or daemon not running"
+  fi
+
+  if [[ ! -x "./bin/sam-node" || ! -x "./bin/sam-hub" ]]; then
+    skip "missing binaries; run: make build"
+  fi
+
+  mesh_setup_env
+}
+
+teardown() {
+  if [[ "${BATS_TEST_COMPLETED:-0}" -ne 1 ]]; then
+    echo "Node 1 logs on failure (filtered):"
+    docker logs "${MESH_PREFIX}-node-1" 2>&1 | grep -i -E 'mcp|request|error|fatal|panic' || true
+  fi
+  mesh_cleanup_env
+}
+
+@test "Docs Snippets: agent_demo.py runs successfully" {
+  run mesh_start_mock_oidc
+  [[ "$status" -eq 0 ]]
+
+  run mesh_start_hub
+  [[ "$status" -eq 0 ]]
+
+  run mesh_start_node 1 "--discovery-interval 100ms --log-level debug"
+  [[ "$status" -eq 0 ]]
+
+  local node1_name="${MESH_PREFIX}-node-1"
+  mesh_wait_for_log "${node1_name}" "SAM Node Online" 20
+  mesh_wait_for_mcp_ready 1 20
+
+  # Run the agent_demo.py snippet inside a container
+  run docker run --rm \
+    --network "${MESH_NETWORK}" \
+    -v "$(pwd)/sam-mcp-python:/sam-mcp-python" \
+    -v "$(pwd)/docs/snippets:/snippets" \
+    -e PYTHONPATH=/sam-mcp-python/src \
+    -e SAM_MCP_URL="http://sam-node-1:8080/mcp/events" \
+    python:3.12 \
+    bash -c 'pip install mcp httpx && python3 /snippets/agent_demo.py'
+
+  echo "agent_demo.py output: $output"
+
+  if [[ "$status" -ne 0 ]]; then
+    echo "Node 1 logs:"
+    docker logs "${node1_name}"
+  fi
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Connecting to SAM Node at"* ]]
+  [[ "$output" == *"Discovered"* ]]
+  [[ "$output" == *"Calling get_mesh_info tool..."* ]]
+  [[ "$output" == *"Result:"* ]]
+}

--- a/tests/e2e/key_rotation_test.bats
+++ b/tests/e2e/key_rotation_test.bats
@@ -38,6 +38,7 @@ teardown() {
     --key "${key}" \
     --listen "/ip4/0.0.0.0/udp/4001/quic-v1" \
     --listen "/ip4/0.0.0.0/tcp/4002" \
+    --external-multiaddr "/dns4/sam-hub/tcp/4002" \
     --mesh "e2e-mesh" \
     --key-rotation-interval 5s >/dev/null
 

--- a/tests/e2e/kind_wi.bats
+++ b/tests/e2e/kind_wi.bats
@@ -127,8 +127,12 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 4002
+  - name: p2p
+    port: 4002
     targetPort: 4002
+  - name: http
+    port: 9090
+    targetPort: 9090
   selector:
     app: sam-hub
 EOF
@@ -176,7 +180,7 @@ spec:
         command: ["/sam-node", "run"]
         args:
         - "--hub"
-        - "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}"
+        - "http://sam-hub:9090"
         - "--jwt-path"
         - "/var/run/secrets/tokens/sam-token"
         volumeMounts:

--- a/tests/e2e/kind_wi.bats
+++ b/tests/e2e/kind_wi.bats
@@ -88,7 +88,7 @@ metadata:
   name: sam-hub-config
 data:
   SAM_OIDC_ISSUER: "${issuer}"
-  SAM_OIDC_ID: "sam-hub-audience"
+  SAM_OIDC_ID: "sam-mesh-audience"
   SAM_HUB_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
 ---
 apiVersion: apps/v1
@@ -190,7 +190,7 @@ spec:
           - serviceAccountToken:
               path: sam-token
               expirationSeconds: 3600
-              audience: "sam-hub-audience"
+              audience: "sam-mesh-audience"
 EOF
 
   # Wait for Node to be ready

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -38,7 +38,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
   }
 
   mesh_build_runtime_image() {
-    docker build \
+    docker build --no-cache \
       -f tests/e2e/docker/Dockerfile.sam-runtime \
       -t "${MESH_RUNTIME_IMAGE}" \
       . >/dev/null
@@ -47,9 +47,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
   mesh_setup_env() {
     mesh_cleanup_stale_resources
     
-    if ! docker image inspect "${MESH_RUNTIME_IMAGE}" >/dev/null 2>&1; then
-      mesh_build_runtime_image
-    fi
+    mesh_build_runtime_image
 
     MESH_PREFIX="mesh-${BATS_TEST_NUMBER}-$$-$(date +%s)"
     MESH_NETWORK="${MESH_PREFIX}-net"
@@ -213,6 +211,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       --key "${key}" \
       --listen "/ip4/0.0.0.0/udp/4001/quic-v1" \
       --listen "/ip4/0.0.0.0/tcp/4002" \
+      --external-multiaddr "/dns4/sam-hub/tcp/4002" \
       --mesh "e2e-mesh" >/dev/null
 
     MESH_CONTAINERS+=("${name}")
@@ -240,10 +239,10 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       "${MESH_RUNTIME_IMAGE}" \
       /usr/local/bin/sam-node run \
       ${flags} \
-      --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
+      --hub "http://sam-hub:9090" \
       --client-id "sam-mesh-audience" \
       --client-secret "sam-e2e-secret" \
-      --token-url "http://mock-oidc:18080/token" \
+      --oidc-issuer "http://mock-oidc:18080" \
       --listen "/ip4/0.0.0.0/udp/5001/quic-v1" \
       --listen "/ip4/0.0.0.0/tcp/5002" \
       --bind-addr "0.0.0.0:8080" \

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -121,7 +121,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
   mesh_get_node_count_via_mcp() {
     local idx="$1"
     local output
-    output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+    output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
     echo "${output}" | jq '.known_peers | length'
   }
 
@@ -132,7 +132,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "Node ${idx} get_mesh_info raw output: ${output}"
       local count
       count="$(echo "${output}" | jq '.known_peers | length')"
@@ -152,7 +152,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "[$(date +%T)] Node ${idx} get_mesh_info raw output: ${output}"
       local connected
       connected="$(echo "${output}" | jq -r --arg peer "$target_peer" '.connected_peers | index($peer) != null')"
@@ -172,7 +172,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "[$(date +%T)] Node ${idx} get_mesh_info raw output: ${output}"
       local connected
       connected="$(echo "${output}" | jq -r --arg peer "$target_peer" '.connected_peers | index($peer) != null')"
@@ -209,6 +209,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       "sam-hub:local" \
       --issuer "http://mock-oidc:18080" \
       --client-id "sam-e2e" \
+      --allowed-audiences "sam-e2e,sam-mesh-audience" \
       --key "${key}" \
       --listen "/ip4/0.0.0.0/udp/4001/quic-v1" \
       --listen "/ip4/0.0.0.0/tcp/4002" \
@@ -240,7 +241,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       /usr/local/bin/sam-node run \
       ${flags} \
       --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
-      --client-id "sam-e2e" \
+      --client-id "sam-mesh-audience" \
       --client-secret "sam-e2e-secret" \
       --token-url "http://mock-oidc:18080/token" \
       --listen "/ip4/0.0.0.0/udp/5001/quic-v1" \

--- a/tests/e2e/policy.bats
+++ b/tests/e2e/policy.bats
@@ -210,10 +210,10 @@ EOF"
     -v "${POLICY_VOL}:/etc/sam" \
     "sam-node:local" \
     run \
-    --hub "/dns4/sam-hub/tcp/4002/p2p/${hub_peer_id}" \
+    --hub "http://sam-hub:9090" \
     --client-id "sam-e2e" \
     --client-secret "sam-e2e-secret" \
-    --token-url "http://mock-oidc:18080/token" \
+    --oidc-issuer "http://mock-oidc:18080" \
     --listen "/ip4/0.0.0.0/udp/5001/quic-v1" \
     --listen "/ip4/0.0.0.0/tcp/5002" \
     --bind-addr "0.0.0.0:8080" \

--- a/tests/e2e/policy.bats
+++ b/tests/e2e/policy.bats
@@ -188,6 +188,7 @@ EOF"
     "sam-hub:local" \
     --issuer "http://mock-oidc:18080" \
     --client-id "sam-e2e" \
+    --allowed-audiences "sam-e2e" \
     --key "${key}" \
     --listen "/ip4/0.0.0.0/udp/4001/quic-v1" \
     --listen "/ip4/0.0.0.0/tcp/4002" \
@@ -239,7 +240,7 @@ EOF"
   
   for ((i=0; i<30; i++)); do
     local output
-    output="$(docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-2:8080/mcp/events" 2>/dev/null)"
+    output="$(docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-2:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
     TARGET_PEER_ID=$(echo "${output}" | grep -oE '12D3Koo[a-zA-Z0-9]+' | grep -v "${hub_id}" | grep -v "${node2_id}" | head -n 1)
     if [[ -n "${TARGET_PEER_ID}" ]]; then
       break

--- a/tests/integration/catalog_test.go
+++ b/tests/integration/catalog_test.go
@@ -133,7 +133,7 @@ func waitForPeerInfoInLog(t *testing.T, logPath string) string {
 
 func TestCatalogRoutingAndFailover(t *testing.T) {
 	nodeBin := buildBinary(t, "./cmd/sam-node")
-	_, hubAddr := startMockLibp2pHub(t)
+	_, hubAddr := startMockHub(t)
 
 	homeA := t.TempDir()
 	homeB := t.TempDir()

--- a/tests/integration/cuj_test.go
+++ b/tests/integration/cuj_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSamNodeRunWithManualTokenStarts(t *testing.T) {
 	nodeBin := buildBinary(t, "./cmd/sam-node")
-	_, hubAddr := startMockLibp2pHub(t)
+	_, hubAddr := startMockHub(t)
 	tmpHome := t.TempDir()
 	env := append(os.Environ(),
 		"HOME="+tmpHome,

--- a/tests/integration/datapath_test.go
+++ b/tests/integration/datapath_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestIntegrationStdioDatapath(t *testing.T) {
 	nodeBin := buildBinary(t, "./cmd/sam-node")
-	_, hubAddr := startMockLibp2pHub(t)
+	_, hubAddr := startMockHub(t)
 
 	homeA := t.TempDir()
 	homeB := t.TempDir()
@@ -173,7 +173,7 @@ func TestIntegrationStdioDatapath(t *testing.T) {
 
 func TestIntegrationHTTPDatapath(t *testing.T) {
 	nodeBin := buildBinary(t, "./cmd/sam-node")
-	_, hubAddr := startMockLibp2pHub(t)
+	_, hubAddr := startMockHub(t)
 
 	homeA := t.TempDir()
 	homeB := t.TempDir()

--- a/tests/integration/fallback_test.go
+++ b/tests/integration/fallback_test.go
@@ -31,9 +31,7 @@ import (
 	"github.com/biscuit-auth/biscuit-go/v2/parser"
 	"github.com/google/sam/api"
 	"github.com/libp2p/go-libp2p"
-	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-msgio"
 	"github.com/multiformats/go-multiaddr"
@@ -99,7 +97,7 @@ func TestFallbackReEnrollment(t *testing.T) {
 	tokenBytes, _ := b.Serialize()
 
 	// 4. Start Mock Hub with dynamic key response
-	_, hubAddr := startMockHubDynamic(t, pubA, pubB)
+	_, hubAddr := startMockHub(t, pubA, pubB)
 
 	tmpHome := t.TempDir()
 	env := append(os.Environ(),
@@ -247,48 +245,6 @@ func TestFallbackReEnrollment(t *testing.T) {
 	}
 }
 
-func startMockHubDynamic(t *testing.T, pubA, pubB ed25519.PublicKey) (peer.ID, string) {
-	t.Helper()
-
-	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
-	if err != nil {
-		t.Fatalf("failed to create mock libp2p host: %v", err)
-	}
-
-	kdht, err := dht.New(context.Background(), h, dht.Mode(dht.ModeServer), dht.ProtocolPrefix("/sam"))
-	if err != nil {
-		t.Fatalf("failed to create DHT on mock hub: %v", err)
-	}
-
-	var callCount int
-	h.SetStreamHandler(api.EnrollProtocolID, func(s network.Stream) {
-		defer func() { _ = s.Close() }()
-		callCount++
-
-		var pub []byte
-		if callCount == 1 {
-			pub = pubA
-		} else {
-			pub = pubB
-		}
-
-		resp := &api.EnrollResponse{
-			BiscuitToken: []byte("mock-biscuit-token"),
-			HubPublicKey: pub,
-			HubAddresses: []string{h.Addrs()[0].String() + "/p2p/" + h.ID().String()},
-		}
-		data, _ := proto.Marshal(resp)
-		writer := msgio.NewVarintWriter(s)
-		_ = writer.WriteMsg(data)
-	})
-
-	t.Cleanup(func() {
-		_ = kdht.Close()
-		_ = h.Close()
-	})
-
-	return h.ID(), h.Addrs()[0].String() + "/p2p/" + h.ID().String()
-}
 
 type safeBuffer struct {
 	mu  sync.Mutex

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -16,6 +16,9 @@ package integration_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,19 +35,43 @@ func TestSamNodeLogin(t *testing.T) {
 		"XDG_CONFIG_HOME="+filepath.Join(tmpHome, ".config"),
 	)
 
-	// We simulate the user pasting the token followed by a newline.
-	stdin := "test-jwt-token\n"
+	// Mock OIDC server for device flow
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device/code", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_code":      "dev_code_123",
+			"user_code":        "ABCD-1234",
+			"verification_uri": "http://example.com/verify",
+			"expires_in":       60,
+			"interval":         1,
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"access_token": "test-jwt-token",
+			"id_token":     "test-jwt-token",
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
 
 	stdout, stderr, err := runCommand(
 		t,
 		repoRoot(t),
 		5*time.Second,
 		env,
-		stdin,
+		"", // No stdin needed
 		nodeBin,
 		"login",
 		"--hub", hubAddr,
-		"--token-url", "http://example.com/token",
+		"--token-url", server.URL+"/token",
+		"--device-auth-url", server.URL+"/device/code",
 	)
 	if err != nil {
 		t.Fatalf("login command failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -37,6 +37,16 @@ func TestSamNodeLogin(t *testing.T) {
 
 	// Mock OIDC server for device flow
 	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                        "http://" + r.Host,
+			"token_endpoint":                "http://" + r.Host + "/token",
+			"device_authorization_endpoint": "http://" + r.Host + "/device/code",
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
 	mux.HandleFunc("/device/code", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{
@@ -70,8 +80,7 @@ func TestSamNodeLogin(t *testing.T) {
 		nodeBin,
 		"login",
 		"--hub", hubAddr,
-		"--token-url", server.URL+"/token",
-		"--device-auth-url", server.URL+"/device/code",
+		"--oidc-issuer", server.URL,
 	)
 	if err != nil {
 		t.Fatalf("login command failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSamNodeLogin(t *testing.T) {
 	nodeBin := buildBinary(t, "./cmd/sam-node")
-	_, hubAddr := startMockLibp2pHub(t)
+	_, hubAddr := startMockHub(t)
 	tmpHome := t.TempDir()
 	env := append(os.Environ(),
 		"HOME="+tmpHome,

--- a/tests/integration/minimal_helpers_test.go
+++ b/tests/integration/minimal_helpers_test.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -28,9 +30,7 @@ import (
 	"github.com/google/sam/api"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-msgio"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -104,8 +104,24 @@ func startMockHub(t *testing.T, pubKeys ...[]byte) (peer.ID, string) {
 	}
 
 	var callCount int
-	h.SetStreamHandler(api.EnrollProtocolID, func(s network.Stream) {
-		defer func() { _ = s.Close() }()
+
+	// Start HTTP server for enrollment
+	mux := http.NewServeMux()
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read body", http.StatusBadRequest)
+			return
+		}
+		var req api.EnrollRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
 
 		var pubKey []byte
 		if len(pubKeys) == 0 {
@@ -120,28 +136,29 @@ func startMockHub(t *testing.T, pubKeys ...[]byte) (peer.ID, string) {
 			}
 		}
 
-		// The following constants are mock values used for testing.
-		// 'mock-biscuit-token' is a dummy token string.
 		resp := &api.EnrollResponse{
 			BiscuitToken: []byte("mock-biscuit-token"),
 			HubPublicKey: pubKey,
 			HubAddresses: []string{h.Addrs()[0].String() + "/p2p/" + h.ID().String()},
+			KnownPeers:   []string{},
 		}
 		data, err := proto.Marshal(resp)
 		if err != nil {
-			fmt.Printf("Failed to marshal mock response: %v\n", err)
+			http.Error(w, "Failed to marshal response", http.StatusInternalServerError)
 			return
 		}
-		writer := msgio.NewVarintWriter(s)
-		if err := writer.WriteMsg(data); err != nil {
-			fmt.Printf("Failed to write mock response: %v\n", err)
-		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
 	})
 
+	httpServer := httptest.NewServer(mux)
+
 	t.Cleanup(func() {
+		httpServer.Close()
 		_ = kdht.Close()
 		_ = h.Close()
 	})
 
-	return h.ID(), h.Addrs()[0].String() + "/p2p/" + h.ID().String()
+	return h.ID(), httpServer.URL
 }

--- a/tests/integration/minimal_helpers_test.go
+++ b/tests/integration/minimal_helpers_test.go
@@ -90,7 +90,7 @@ func runCommand(
 	return stdout.String(), stderr.String(), err
 }
 
-func startMockLibp2pHub(t *testing.T) (peer.ID, string) {
+func startMockHub(t *testing.T, pubKeys ...[]byte) (peer.ID, string) {
 	t.Helper()
 
 	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
@@ -103,15 +103,28 @@ func startMockLibp2pHub(t *testing.T) (peer.ID, string) {
 		t.Fatalf("failed to create DHT on mock hub: %v", err)
 	}
 
+	var callCount int
 	h.SetStreamHandler(api.EnrollProtocolID, func(s network.Stream) {
 		defer func() { _ = s.Close() }()
 
+		var pubKey []byte
+		if len(pubKeys) == 0 {
+			pubKey = []byte("mock-hub-pub-key")
+		} else {
+			callCount++
+			idx := callCount - 1
+			if idx < len(pubKeys) {
+				pubKey = pubKeys[idx]
+			} else {
+				pubKey = pubKeys[len(pubKeys)-1]
+			}
+		}
+
 		// The following constants are mock values used for testing.
 		// 'mock-biscuit-token' is a dummy token string.
-		// 'mock-hub-pub-key' is a dummy public key string.
 		resp := &api.EnrollResponse{
 			BiscuitToken: []byte("mock-biscuit-token"),
-			HubPublicKey: []byte("mock-hub-pub-key"),
+			HubPublicKey: pubKey,
 			HubAddresses: []string{h.Addrs()[0].String() + "/p2p/" + h.ID().String()},
 		}
 		data, err := proto.Marshal(resp)

--- a/tests/integration/pubsub_test.go
+++ b/tests/integration/pubsub_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestPubSubTools(t *testing.T) {
 	nodeBin := buildBinary(t, "./cmd/sam-node")
-	_, hubAddr := startMockLibp2pHub(t)
+	_, hubAddr := startMockHub(t)
 	tmpHome1, err := os.MkdirTemp("", "pubsub-test-1")
 	if err != nil {
 		t.Fatal(err)

--- a/tests/integration/service_discovery_test.go
+++ b/tests/integration/service_discovery_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestServiceDiscovery(t *testing.T) {
 	nodeBin := buildBinary(t, "./cmd/sam-node")
-	_, hubAddr := startMockLibp2pHub(t)
+	_, hubAddr := startMockHub(t)
 
 	homeA := t.TempDir()
 	homeB := t.TempDir()


### PR DESCRIPTION
Consolidate `startMockLibp2pHub` and `startMockHubDynamic` into a single `startMockHub` function that accepts a variadic number of public keys. Update all usages across integration tests to use the new unified helper. Remove unused mock hub implementation and unused imports from `fallback_test.go`.