### PR TITLE
Enable cross-platform e2e test runs

### DIFF
--- a/tests/e2e/datapath.bats
+++ b/tests/e2e/datapath.bats
@@ -55,7 +55,7 @@ teardown() {
   # Explicitly connect Node 1 to Node 2 (DHT auto-discovery is slow/unreliable in this E2E setup)
   echo "[$(date +%T)] Explicitly connecting Node 1 to Node 2"
   local node2_addr="/dns4/sam-node-2/tcp/5002/p2p/${node2_peer_id}"
-  run docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-1:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node2_addr}\"}"
+  run docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-1:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node2_addr}\"}"
   [[ "$status" -eq 0 ]]
 
   # Verify connection

--- a/tests/e2e/docker/Dockerfile.sam-runtime
+++ b/tests/e2e/docker/Dockerfile.sam-runtime
@@ -1,12 +1,29 @@
+# syntax=docker/dockerfile:1.7
+
+# Build container: compiles the Go binaries via `make build`.
+FROM golang:1.25-alpine AS build
+
+WORKDIR /src
+RUN apk add --no-cache git make
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make build
+
+# Final container: minimal alpine runtime hosting the built binaries.
 FROM alpine:3.20
 
 RUN apk add --no-cache busybox
 
 RUN addgroup -S sam && adduser -S -G sam sam
 
-COPY bin/sam-node /usr/local/bin/sam-node
-COPY bin/sam-hub /usr/local/bin/sam-hub
-RUN chmod +x /usr/local/bin/sam-node /usr/local/bin/sam-hub
+COPY --from=build /src/bin/ /usr/local/bin/
 
 USER sam
 WORKDIR /home/sam

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -119,7 +119,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
   mesh_get_node_count_via_mcp() {
     local idx="$1"
     local output
-    output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
+    output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
     echo "${output}" | jq '.known_peers | length'
   }
 
@@ -130,7 +130,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "Node ${idx} get_mesh_info raw output: ${output}"
       local count
       count="$(echo "${output}" | jq '.known_peers | length')"
@@ -150,7 +150,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "[$(date +%T)] Node ${idx} get_mesh_info raw output: ${output}"
       local connected
       connected="$(echo "${output}" | jq -r --arg peer "$target_peer" '.connected_peers | index($peer) != null')"
@@ -170,7 +170,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local i
     for ((i=0; i<timeout_s; i++)); do
       local output
-      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
+      output="$(timeout 15s docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-${idx}:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
       echo "[$(date +%T)] Node ${idx} get_mesh_info raw output: ${output}"
       local connected
       connected="$(echo "${output}" | jq -r --arg peer "$target_peer" '.connected_peers | index($peer) != null')"

--- a/tests/e2e/policy.bats
+++ b/tests/e2e/policy.bats
@@ -131,7 +131,7 @@ mesh_call_remote_tool() {
   
   local args="{\"peer_id\":\"${target_peer_id}\",\"tool_name\":\"${tool_name}\",\"arguments\":\"{}\"}"
   
-  docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-${caller_idx}:8080/mcp/events" -tool "call_remote_tool" -args "${args}"
+  docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-${caller_idx}:8080/mcp/events" -tool "call_remote_tool" -args "${args}"
 }
 
 setup() {
@@ -240,7 +240,7 @@ EOF"
   
   for ((i=0; i<40; i++)); do
     local output
-    output="$(docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-2:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
+    output="$(docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-2:8080/mcp/events" -tool "get_mesh_info" 2>/dev/null)"
     TARGET_PEER_ID=$(echo "${output}" | grep -oE '12D3Koo[a-zA-Z0-9]+' | grep -v "${hub_id}" | grep -v "${node2_id}" | head -n 1)
     if [[ -n "${TARGET_PEER_ID}" ]]; then
       break
@@ -258,7 +258,7 @@ EOF"
 
   # Explicitly connect Node 2 to Node 1 to avoid "no addresses" error
   local node1_addr="/dns4/sam-node-1/tcp/5002/p2p/${TARGET_PEER_ID}"
-  docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-2:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node1_addr}\"}" >/dev/null
+  docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-2:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node1_addr}\"}" >/dev/null
 }
 
 teardown() {

--- a/tests/e2e/revocation_test.bats
+++ b/tests/e2e/revocation_test.bats
@@ -75,7 +75,7 @@ teardown() {
   # Explicitly connect Node 1 to Node 2
   echo "[$(date +%T)] Explicitly connecting Node 1 to Node 2"
   local node2_addr="/dns4/sam-node-2/tcp/5002/p2p/${node2_peer_id}"
-  run docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-1:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node2_addr}\"}"
+  run docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-1:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node2_addr}\"}"
   [[ "$status" -eq 0 ]]
 
   # Verify Node 1 connects to Node 2
@@ -117,7 +117,7 @@ teardown() {
   # Verify Node 1 cannot reconnect to Node 2
   echo "[$(date +%T)] Attempting to reconnect (should fail)"
   local node2_addr="/dns4/sam-node-2/tcp/5002/p2p/${node2_peer_id}"
-  run docker run --rm --network "${MESH_NETWORK}" -v "$(pwd)/bin/mcp-client:/mcp-client" python:3.12 /mcp-client -url "http://sam-node-1:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node2_addr}\"}"
+  run docker run --rm --network "${MESH_NETWORK}" "${MESH_RUNTIME_IMAGE}" mcp-client -url "http://sam-node-1:8080/mcp/events" -tool "connect_peer" -args "{\"peer_addr\":\"${node2_addr}\"}"
   echo "Reconnect output: $output"
   [[ "$output" == *"gater disallows connection"* ]]
 }

--- a/tests/e2e/services.bats
+++ b/tests/e2e/services.bats
@@ -70,8 +70,7 @@ teardown() {
   echo "[$(date +%T)] Connecting Node 1 to Node 2"
   local node2_addr="/dns4/sam-node-2/tcp/5002/p2p/${node2_peer_id}"
   run docker run --rm --network "${MESH_NETWORK}" \
-    -v "$(pwd)/bin/mcp-client:/mcp-client" \
-    python:3.12 /mcp-client \
+    "${MESH_RUNTIME_IMAGE}" mcp-client \
     -url "http://sam-node-1:8080/mcp/events" \
     -tool "connect_peer" \
     -args "{\"peer_addr\":\"${node2_addr}\"}"
@@ -83,8 +82,7 @@ teardown() {
 
   echo "[$(date +%T)] Discovering MCP services from Node 1 (type-only)"
   run docker run --rm --network "${MESH_NETWORK}" \
-    -v "$(pwd)/bin/mcp-client:/mcp-client" \
-    python:3.12 /mcp-client \
+    "${MESH_RUNTIME_IMAGE}" mcp-client \
     -url "http://sam-node-1:8080/mcp/events" \
     -tool "discover_remote_services" \
     -args '{"type":"mcp"}'

--- a/tests/e2e/watch.bats
+++ b/tests/e2e/watch.bats
@@ -9,11 +9,19 @@ setup() {
   export TEST_TMPDIR
   TEST_TMPDIR="$(mktemp -d)"
   export HOME="$TEST_TMPDIR/home"
-  export XDG_CONFIG_HOME="$HOME/.config"
-  mkdir -p "$XDG_CONFIG_HOME"
+
+  # Match os.UserConfigDir per OS so gen_db.go and sam-node agree on the path.
+  # On Linux, os.UserConfigDir honors $XDG_CONFIG_HOME before $HOME/.config, so
+  # export it to keep both processes in sync even when the host has it set.
+  case "$(uname)" in
+    Darwin) DB_PATH="$HOME/Library/Application Support/sam-mesh/agent.db" ;;
+    *)      export XDG_CONFIG_HOME="$HOME/.config"
+            DB_PATH="$XDG_CONFIG_HOME/sam-mesh/agent.db" ;;
+  esac
+  mkdir -p "$(dirname "$DB_PATH")"
 
   # Generate mock DB
-  go run tests/e2e/gen_db.go "$XDG_CONFIG_HOME/sam-mesh/agent.db"
+  go run tests/e2e/gen_db.go "$DB_PATH"
 }
 
 teardown() {


### PR DESCRIPTION
This PR enables building and running e2e tests in platforms other than Linux (such as MacOS)