### PR TITLE
fix: add context timeout to mcp ListTools to prevent node initializat…

### DIFF
--- a/cmd/sam-node/mcp_service.go
+++ b/cmd/sam-node/mcp_service.go
@@ -105,7 +105,9 @@ func (m *MCPService) Init(ctx context.Context) error {
 	}
 	m.session = s
 
-	res, err := s.ListTools(ctx, nil)
+	listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := s.ListTools(listCtx, nil)
 	if err != nil {
 		logger.Warnf("[MCPService] %s: tools/list failed: %v", m.info.Name, err)
 		success = true


### PR DESCRIPTION
…ion hang

When an MCP server is unresponsive (e.g. openclaw failing to authenticate), ListTools can hang indefinitely, preventing sam-node from finishing its Init phase. This prevents the pod from becoming Ready, which ultimately causes the Kubernetes deployment rollout to fail.

Adding a timeout ensures that sam-node can gracefully handle the error, continue initialization, and mark the pod as Ready, allowing the deployment to succeed.