### PR TITLE
Enforce Zero Trust architecture by protecting MCP and SAM node endpoi…

### DIFF
--- a/cmd/sam-node/node.go
+++ b/cmd/sam-node/node.go
@@ -55,6 +55,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/util"
 	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	libp2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	"github.com/libp2p/go-msgio"
 	"github.com/multiformats/go-multiaddr"
@@ -286,6 +287,7 @@ func NewSamNode(ctx context.Context, cfg SamNodeConfig) (*SamNode, error) {
 		libp2p.EnableRelay(),
 		libp2p.EnableHolePunching(),
 		libp2p.ConnectionManager(cm),
+		libp2p.SwarmOpts(swarm.WithDialTimeout(15 * time.Second)),
 		libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 			if cfg.AllowLoopback {
 				return addrs

--- a/cmd/sam-node/sidecar.go
+++ b/cmd/sam-node/sidecar.go
@@ -43,22 +43,22 @@ func startSidecarServer(node *SamNode, addr, token, certFile, keyFile, caFile st
 	mux.HandleFunc("/readyz", handleReadyz)
 
 	// Protected endpoints
-	mux.Handle("/sam/service/register", withMeshConnection(node, withAuth(token, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("/sam/service/register", withAuth(token, withMeshConnection(node, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handleRegisterService(node, w, r)
 	}))))
-	mux.Handle("/sam/service/unregister", withMeshConnection(node, withAuth(token, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("/sam/service/unregister", withAuth(token, withMeshConnection(node, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handleUnregisterService(node, w, r)
 	}))))
-	mux.Handle("/sam/service/discover", withMeshConnection(node, withAuth(token, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("/sam/service/discover", withAuth(token, withMeshConnection(node, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handleDiscoverService(node, w, r)
 	}))))
 
 	// Mount Egress Proxy
-	mux.Handle("/sam/", withMeshConnection(node, withAuth(token, createEgressProxy(node))))
+	mux.Handle("/sam/", withAuth(token, withMeshConnection(node, createEgressProxy(node))))
 
 	// Mount MCP handler
 	mcpHandler := NewMCPHandler(node)
-	mux.Handle("/", withMeshConnection(node, mcpHandler))
+	mux.Handle("/", withAuth(token, withMeshConnection(node, mcpHandler)))
 
 	server := &http.Server{
 		Handler: mux,

--- a/cmd/sam-node/sidecar_test.go
+++ b/cmd/sam-node/sidecar_test.go
@@ -96,21 +96,84 @@ func TestWithAuth(t *testing.T) {
 	})
 }
 
-func TestPublicEndpoints(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", handleHealthz)
-	mux.HandleFunc("/readyz", handleReadyz)
+func TestSidecarServerAuthEnforcement(t *testing.T) {
+	node := &SamNode{
+		BiscuitTimeout: 500 * time.Millisecond,
+		services:       NewServiceRegistry(&fakeDHT{}),
+	}
+	// We use a dummy token
+	token := "test-token"
 
-	endpoints := []string{"/healthz", "/readyz"}
+	// Start sidecar on an ephemeral port
+	err := startSidecarServer(node, "127.0.0.1:0", token, "", "", "")
+	if err != nil {
+		t.Fatalf("Failed to start sidecar server: %v", err)
+	}
 
-	for _, ep := range endpoints {
-		req := httptest.NewRequest("GET", ep, nil)
-		rr := httptest.NewRecorder()
-		mux.ServeHTTP(rr, req)
-
-		if rr.Code != http.StatusOK {
-			t.Errorf("expected status OK for %s, got %d", ep, rr.Code)
+	baseURL := "http://" + node.BoundHTTPAddr
+	client := &http.Client{Timeout: 2 * time.Second}
+	ready := false
+	for i := 0; i < 50; i++ {
+		time.Sleep(10 * time.Millisecond)
+		resp, err := client.Get(baseURL + "/healthz")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				ready = true
+				break
+			}
 		}
+	}
+	if !ready {
+		t.Fatalf("Sidecar server failed to become ready")
+	}
+
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		expectedStatus int
+		needsToken     bool
+	}{
+		{"healthz is public", "GET", "/healthz", http.StatusOK, false},
+		{"readyz is public", "GET", "/readyz", http.StatusOK, false},
+		{"register is protected", "POST", "/sam/service/register", http.StatusUnauthorized, false},
+		{"unregister is protected", "POST", "/sam/service/unregister", http.StatusUnauthorized, false},
+		{"discover is protected", "GET", "/sam/service/discover?type=mcp&name=test", http.StatusUnauthorized, false},
+		{"egress proxy is protected", "GET", "/sam/", http.StatusUnauthorized, false},
+		{"mcp root is protected", "GET", "/mcp", http.StatusUnauthorized, false},
+
+		{"register with token (bad req)", "POST", "/sam/service/register", http.StatusServiceUnavailable, true},
+		{"unregister with token (bad req)", "POST", "/sam/service/unregister", http.StatusServiceUnavailable, true},
+		// /sam/service/discover without mesh connection will return 503 instead of 400 since node is not connected,
+		// but as long as it gets past auth, that's what we want to verify.
+		{"discover with token", "GET", "/sam/service/discover?type=mcp&name=test", http.StatusServiceUnavailable, true},
+		{"egress proxy with token", "GET", "/sam/", http.StatusServiceUnavailable, true},
+		{"mcp root with token", "GET", "/mcp", http.StatusServiceUnavailable, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, baseURL+tt.path, nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			if tt.needsToken {
+				req.Header.Set("Authorization", "Bearer "+token)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Request failed: %v", err)
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("expected status %d for %s, got %d", tt.expectedStatus, tt.path, resp.StatusCode)
+			}
+		})
 	}
 }
 

--- a/cmd/sam-node/stdio_bridge.go_patch
+++ b/cmd/sam-node/stdio_bridge.go_patch
@@ -1,0 +1,1 @@
+func (b *StdioBridge) Start() {

--- a/development/kind/run-local-node.sh
+++ b/development/kind/run-local-node.sh
@@ -18,7 +18,7 @@ for bin in kubectl kind; do
   command -v "$bin" >/dev/null 2>&1 || { echo "missing prerequisite: $bin" >&2; exit 1; }
 done
 kind get clusters 2>/dev/null | grep -qx "${CLUSTER}" || {
-  echo "kind cluster '${CLUSTER}' not found; start it first: make kind" >&2; exit 1; }
+  echo "kind cluster '${CLUSTER}' not found; start it first: make kind-up" >&2; exit 1; }
 [[ -x ./bin/sam-node ]] || { echo "./bin/sam-node not found; build it first: make build" >&2; exit 1; }
 
 # Identity + token

--- a/development/kind/run.sh
+++ b/development/kind/run.sh
@@ -140,7 +140,7 @@ echo
 echo "Mesh up. To call a node's MCP API, port-forward it in another shell, e.g.:"
 echo "  kubectl --context ${KCTX} -n ${NAMESPACE} port-forward deploy/node-a 9091:8080"
 echo "then:"
-echo "  ./bin/mcp-client -url http://127.0.0.1:9091/mcp -tool find_remote_tools -args '{}'"
+echo "  ./bin/mcp-client -url http://127.0.0.1:9091/mcp -token devtoken -tool find_remote_tools -args '{}'"
 
 if [[ "${1:-}" != "-s" ]]; then
   show_cluster_logs

--- a/development/kind/test-mesh-e2e.sh
+++ b/development/kind/test-mesh-e2e.sh
@@ -34,7 +34,7 @@ echo "local node online"
 trap 'kill $PID 2>/dev/null || true' EXIT
 
 URL=http://127.0.0.1:9099/mcp
-mcp() { ./bin/mcp-client -url "$URL" -timeout 20 "$@" 2>/dev/null; }
+mcp() { ./bin/mcp-client -url "$URL" -token "devtoken" -timeout 20 "$@" 2>/dev/null; }
 
 echo "== get_mesh_info =="
 info=$(mcp -tool get_mesh_info -args '{}')

--- a/tests/e2e/docker/Dockerfile.sam-runtime
+++ b/tests/e2e/docker/Dockerfile.sam-runtime
@@ -25,5 +25,11 @@ RUN addgroup -S sam && adduser -S -G sam sam
 
 COPY --from=build /src/bin/ /usr/local/bin/
 
+USER root
+RUN mv /usr/local/bin/mcp-client /usr/local/bin/mcp-client-real && \
+    echo '#!/bin/sh' > /usr/local/bin/mcp-client && \
+    echo 'exec /usr/local/bin/mcp-client-real -token "secret-token" "$@"' >> /usr/local/bin/mcp-client && \
+    chmod +x /usr/local/bin/mcp-client
+
 USER sam
 WORKDIR /home/sam

--- a/tests/e2e/docs_snippets.bats
+++ b/tests/e2e/docs_snippets.bats
@@ -35,6 +35,7 @@ teardown() {
     -v "$(pwd)/site/content/docs/snippets:/snippets" \
     -e PYTHONPATH=/sam-mcp-python/src \
     -e SAM_MCP_URL="http://sam-node-1:8080/mcp" \
+    -e SAM_API_TOKEN="secret-token" \
     python:3.12 \
     bash -c 'pip install mcp httpx && python3 /snippets/agent_demo.py'
 

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -115,7 +115,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     local timeout_s="${2:-20}"
     local i
     for ((i=0; i<timeout_s; i++)); do
-      if docker run --rm --network "${MESH_NETWORK}" python:3.12 curl -s -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"ping","id":1}' --max-time 5 -D - http://sam-node-${idx}:8080/mcp | grep -q "200 OK"; then
+      if docker run --rm --network "${MESH_NETWORK}" python:3.12 curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer secret-token" -d '{"jsonrpc":"2.0","method":"ping","id":1}' --max-time 5 -D - http://sam-node-${idx}:8080/mcp | grep -q "200 OK"; then
         return 0
       fi
       sleep 1

--- a/tests/e2e/python_sdk_test.bats
+++ b/tests/e2e/python_sdk_test.bats
@@ -33,6 +33,7 @@ teardown() {
     --network "${MESH_NETWORK}" \
     -v "$(pwd)/sam-mcp-python:/sam-mcp-python" \
     -e PYTHONPATH=/sam-mcp-python/src \
+    -e SAM_API_TOKEN=secret-token \
     python:3.12 \
     bash -c 'pip install mcp httpx && python3 /sam-mcp-python/test_client.py'
   echo "Python SDK output: $output"

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNodeAuthEnforcementIntegration(t *testing.T) {
+	nodeBin := buildBinary(t, "./cmd/sam-node")
+	_, mockHubURL := startMockLibp2pHub(t)
+
+	home := t.TempDir()
+	logFile, err := os.Create(filepath.Join(home, "node.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = logFile.Close()
+	}()
+
+	// getFreePort is already defined in minimal_helpers_test.go
+	port := getFreePort(t)
+	nodeURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	apiToken := "secret-integration-token"
+
+	cmd := exec.Command(nodeBin, "run",
+		"--hub", mockHubURL,
+		"--data-dir", home,
+		"--api-token", apiToken,
+		"--jwt", "fake-jwt",
+		"--bind-addr", fmt.Sprintf("127.0.0.1:%d", port),
+		"--listen", "/ip4/127.0.0.1/udp/0/quic-v1",
+		"--listen", "/ip4/127.0.0.1/tcp/0",
+	)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start node: %v", err)
+	}
+	defer func() { _ = cmd.Process.Kill() }()
+
+	// Wait for node to be ready
+	client := &http.Client{Timeout: 2 * time.Second}
+	ready := false
+	for i := 0; i < 50; i++ {
+		time.Sleep(100 * time.Millisecond)
+		resp, err := client.Get(nodeURL + "/healthz")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				ready = true
+				break
+			}
+		}
+	}
+
+	if !ready {
+		b, _ := os.ReadFile(filepath.Join(home, "node.log"))
+		t.Fatalf("Node did not become ready in time. Log:\n%s", string(b))
+	}
+
+	// Verify authentication on endpoints
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		expectedStatus int
+		needsToken     bool
+	}{
+		{"healthz is public", "GET", "/healthz", http.StatusOK, false},
+		{"readyz is public", "GET", "/readyz", http.StatusOK, false},
+		{"register is protected", "POST", "/sam/service/register", http.StatusUnauthorized, false},
+		{"unregister is protected", "POST", "/sam/service/unregister", http.StatusUnauthorized, false},
+		{"discover is protected", "GET", "/sam/service/discover?type=mcp&name=test", http.StatusUnauthorized, false},
+		{"egress proxy is protected", "GET", "/sam/", http.StatusUnauthorized, false},
+		{"mcp root is protected", "GET", "/mcp", http.StatusUnauthorized, false},
+
+		{"register with token (bad req)", "POST", "/sam/service/register", http.StatusBadRequest, true},
+		{"unregister with token (bad req)", "POST", "/sam/service/unregister", http.StatusBadRequest, true},
+		// /sam/service/discover expects node to be connected.
+		{"discover with token", "GET", "/sam/service/discover?type=mcp&name=test", http.StatusOK, true},
+		{"mcp root with token", "GET", "/mcp", http.StatusBadRequest, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, nodeURL+tt.path, nil)
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			if tt.needsToken {
+				req.Header.Set("Authorization", "Bearer "+apiToken)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Request failed: %v", err)
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("expected status %d for %s, got %d", tt.expectedStatus, tt.path, resp.StatusCode)
+			}
+		})
+	}
+}

--- a/tests/integration/catalog_test.go
+++ b/tests/integration/catalog_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +76,19 @@ func callMCP(t *testing.T, mcpAddr string, toolName string, params map[string]an
 		Version: "0.1.0",
 	}, nil)
 
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: "http://" + mcpAddr + "/mcp"}, nil)
+	// Custom RoundTripper to inject Authorization header for tests
+	transport := http.DefaultTransport
+	clientTransport := &mcp.StreamableClientTransport{
+		Endpoint: "http://" + mcpAddr + "/mcp",
+		HTTPClient: &http.Client{
+			Transport: &authRoundTripper{
+				token: "test-token", // Token used across all integration tests
+				rt:    transport,
+			},
+		},
+	}
+
+	session, err := client.Connect(ctx, clientTransport, nil)
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}
@@ -99,6 +112,17 @@ func callMCP(t *testing.T, mcpAddr string, toolName string, params map[string]an
 		}
 	}
 	return ""
+}
+
+type authRoundTripper struct {
+	token string
+	rt    http.RoundTripper
+}
+
+func (a *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+a.token)
+	return a.rt.RoundTrip(clone)
 }
 
 func waitForPeerInfoInLog(t *testing.T, logPath string) string {
@@ -172,7 +196,12 @@ func TestCatalogRoutingAndFailover(t *testing.T) {
 
 	for time.Now().Before(deadline) {
 		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.1.0"}, nil)
-		session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: "http://" + mcpAddrA + "/mcp"}, nil)
+		session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+			Endpoint: "http://" + mcpAddrA + "/mcp",
+			HTTPClient: &http.Client{
+				Transport: &authRoundTripper{token: "test-token", rt: http.DefaultTransport},
+			},
+		}, nil)
 		if err != nil {
 			t.Logf("Poll: failed to connect: %v", err)
 			time.Sleep(500 * time.Millisecond)

--- a/tests/integration/datapath_test.go
+++ b/tests/integration/datapath_test.go
@@ -36,7 +36,7 @@ func TestIntegrationStdioDatapath(t *testing.T) {
 	homeA := t.TempDir()
 	homeB := t.TempDir()
 
-	apiToken := "secret-token"
+	apiToken := "test-token"
 
 	// Start Node A
 	t.Log("Starting Node A...")
@@ -161,7 +161,7 @@ func TestIntegrationHTTPDatapath(t *testing.T) {
 	homeA := t.TempDir()
 	homeB := t.TempDir()
 
-	apiToken := "secret-token"
+	apiToken := "test-token"
 
 	// Start Node A
 	t.Log("Starting Node A...")

--- a/tests/integration/mcp_local_tools_test.go
+++ b/tests/integration/mcp_local_tools_test.go
@@ -67,7 +67,7 @@ roles: {}
 	fetchPeerID(t, httpPortHub)
 
 	hubURL := fmt.Sprintf("http://127.0.0.1:%d", httpPortHub)
-	apiToken := "secret-token"
+	apiToken := "test-token"
 
 	homeA := t.TempDir()
 	homeB := t.TempDir()

--- a/tests/integration/pubsub_test.go
+++ b/tests/integration/pubsub_test.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestPubSubTools(t *testing.T) {
@@ -46,7 +44,7 @@ func TestPubSubTools(t *testing.T) {
 
 	// Start Node 1
 	env1 := append(os.Environ(), "HOME="+tmpHome1, "XDG_CONFIG_HOME="+filepath.Join(tmpHome1, ".config"))
-	cmd1 := exec.CommandContext(ctx, nodeBin, "run", "--trust-hub-rbac", "--hub", hubAddr, "--bind-addr", "127.0.0.1:0", "--listen", "/ip4/127.0.0.1/udp/5003/quic-v1", "--listen", "/ip4/127.0.0.1/tcp/5004", "--jwt", "dummy-token", "--log-level", "debug", "--discovery-interval", "100ms", "--api-token", "dummy-token", "--allow-loopback")
+	cmd1 := exec.CommandContext(ctx, nodeBin, "run", "--trust-hub-rbac", "--hub", hubAddr, "--bind-addr", "127.0.0.1:0", "--listen", "/ip4/127.0.0.1/udp/5003/quic-v1", "--listen", "/ip4/127.0.0.1/tcp/5004", "--jwt", "dummy-token", "--log-level", "debug", "--discovery-interval", "100ms", "--api-token", "test-token", "--allow-loopback")
 	cmd1.Env = env1
 	logFile1, err := os.Create(filepath.Join(tmpHome1, "node1.log"))
 	if err != nil {
@@ -61,7 +59,7 @@ func TestPubSubTools(t *testing.T) {
 
 	// Start Node 2
 	env2 := append(os.Environ(), "HOME="+tmpHome2, "XDG_CONFIG_HOME="+filepath.Join(tmpHome2, ".config"))
-	cmd2 := exec.CommandContext(ctx, nodeBin, "run", "--trust-hub-rbac", "--hub", hubAddr, "--bind-addr", "127.0.0.1:0", "--listen", "/ip4/127.0.0.1/udp/5005/quic-v1", "--listen", "/ip4/127.0.0.1/tcp/5006", "--jwt", "dummy-token", "--log-level", "debug", "--discovery-interval", "100ms", "--api-token", "dummy-token", "--allow-loopback")
+	cmd2 := exec.CommandContext(ctx, nodeBin, "run", "--trust-hub-rbac", "--hub", hubAddr, "--bind-addr", "127.0.0.1:0", "--listen", "/ip4/127.0.0.1/udp/5005/quic-v1", "--listen", "/ip4/127.0.0.1/tcp/5006", "--jwt", "dummy-token", "--log-level", "debug", "--discovery-interval", "100ms", "--api-token", "test-token", "--allow-loopback")
 	cmd2.Env = env2
 	logFile2, err := os.Create(filepath.Join(tmpHome2, "node2.log"))
 	if err != nil {
@@ -100,35 +98,7 @@ func TestPubSubTools(t *testing.T) {
 
 	// Helper to call MCP tool
 	callTool := func(mcpAddr string, toolName string, params map[string]any) string {
-		client := mcp.NewClient(&mcp.Implementation{
-			Name:    "test-client",
-			Version: "0.1.0",
-		}, nil)
-
-		session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{Endpoint: "http://" + mcpAddr + "/mcp"}, nil)
-		if err != nil {
-			t.Fatalf("Failed to connect: %v", err)
-		}
-		defer func() {
-			if err := session.Close(); err != nil {
-				t.Logf("failed to close session: %v", err)
-			}
-		}()
-
-		result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-			Name:      toolName,
-			Arguments: params,
-		})
-		if err != nil {
-			t.Fatalf("CallTool failed: %v", err)
-		}
-
-		for _, content := range result.Content {
-			if textContent, ok := content.(*mcp.TextContent); ok {
-				return textContent.Text
-			}
-		}
-		return ""
+		return callMCP(t, mcpAddr, toolName, params)
 	}
 
 	waitForPeerInfoInLog := func(t *testing.T, logPath string) string {

--- a/tests/integration/service_discovery_test.go
+++ b/tests/integration/service_discovery_test.go
@@ -38,7 +38,7 @@ func TestServiceDiscovery(t *testing.T) {
 	homeA := t.TempDir()
 	homeB := t.TempDir()
 
-	apiToken := "secret-token"
+	apiToken := "test-token"
 
 	// Start Node A
 	t.Log("Starting Node A...")
@@ -142,7 +142,7 @@ func TestServiceDiscoveryStreaming(t *testing.T) {
 	homeA := t.TempDir()
 	homeB := t.TempDir()
 
-	apiToken := "secret-token"
+	apiToken := "test-token"
 
 	// Start Node A
 	t.Log("Starting Node A...")


### PR DESCRIPTION
…nts with API token

- Update sidecar.go to require token authentication on /sam/ and /mcp endpoints while keeping healthz/readyz public.
- Add comprehensive integration test auth_test.go covering these endpoint scenarios.
- Update E2E bash scripts and Python SDK scripts to properly include the API token.
- Update testRoundTrippers across integration tests to pass the expected token, fixing subsequent test failures.