### PR TITLE
fix(node): make hub dial timeout configurable

### DIFF
--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -76,6 +76,7 @@ var (
 	autoRelayMinIntervalFlag time.Duration
 	autoRelayBootDelayFlag   time.Duration
 	autoRelayBackoffFlag     time.Duration
+	hubConnectTimeoutFlag    time.Duration
 	apiTokenFlag             string
 	tlsCertFlag              string
 	tlsKeyFlag               string
@@ -220,6 +221,7 @@ func main() {
 					AutoRelayMinInterval: autoRelayMinIntervalFlag,
 					AutoRelayBootDelay:   autoRelayBootDelayFlag,
 					AutoRelayBackoff:     autoRelayBackoffFlag,
+					HubConnectTimeout:    hubConnectTimeoutFlag,
 				})
 				if err != nil {
 					logger.Fatalf("Failed to initialize mesh node: %v", err)
@@ -278,6 +280,7 @@ func main() {
 					AutoRelayMinInterval: autoRelayMinIntervalFlag,
 					AutoRelayBootDelay:   autoRelayBootDelayFlag,
 					AutoRelayBackoff:     autoRelayBackoffFlag,
+					HubConnectTimeout:    hubConnectTimeoutFlag,
 				})
 				if err != nil {
 					enrollCancel()
@@ -329,6 +332,7 @@ func main() {
 					AutoRelayMinInterval: autoRelayMinIntervalFlag,
 					AutoRelayBootDelay:   autoRelayBootDelayFlag,
 					AutoRelayBackoff:     autoRelayBackoffFlag,
+					HubConnectTimeout:    hubConnectTimeoutFlag,
 				})
 				if err != nil {
 					logger.Fatalf("Failed to initialize node after enrollment: %v", err)
@@ -483,6 +487,7 @@ func main() {
 				AutoRelayMinInterval: 30 * time.Second,
 				AutoRelayBootDelay:   0 * time.Second,
 				AutoRelayBackoff:     3 * time.Second,
+				HubConnectTimeout:    hubConnectTimeoutFlag,
 			})
 			if err != nil {
 				logger.Fatalf("Failed to initialize node for enrollment: %v", err)
@@ -521,11 +526,13 @@ func main() {
 	runCmd.Flags().DurationVar(&autoRelayMinIntervalFlag, "autorelay-min-interval", 30*time.Second, "AutoRelay Min Interval")
 	runCmd.Flags().DurationVar(&autoRelayBootDelayFlag, "autorelay-boot-delay", 0*time.Second, "AutoRelay Boot Delay")
 	runCmd.Flags().DurationVar(&autoRelayBackoffFlag, "autorelay-backoff", 3*time.Second, "AutoRelay Backoff")
+	runCmd.Flags().DurationVar(&hubConnectTimeoutFlag, "hub-connect-timeout", node.DefaultHubConnectTimeout, "Timeout for dialing each hub address")
 	runCmd.Flags().BoolVar(&enableRelayFlag, "enable-relay", false, "Allow this node to serve as a relay for others")
 	runCmd.Flags().StringVar(&logLevelFlag, "log-level", "info", "Log level (debug, info, warn, error)")
 	runCmd.Flags().DurationVar(&keyGracePeriodFlag, "key-grace-period", 24*time.Hour, "Key grace period for old keys (e.g. 24h)")
 	runCmd.Flags().BoolVar(&allowLoopbackFlag, "allow-loopback", false, "Allow publishing and connecting to loopback/link-local addresses")
 	joinCmd.Flags().BoolVar(&allowLoopbackFlag, "allow-loopback", false, "Allow publishing and connecting to loopback/link-local addresses")
+	joinCmd.Flags().DurationVar(&hubConnectTimeoutFlag, "hub-connect-timeout", node.DefaultHubConnectTimeout, "Timeout for dialing each hub address")
 	joinCmd.Flags().BoolVar(&offlineAccessFlag, "offline-access", false, "Request OIDC offline access/refresh token for automatic renewal")
 	runCmd.Flags().StringVar(&apiTokenFlag, "api-token", "", "Static Bearer token for API authorization")
 	runCmd.Flags().StringVar(&tlsCertFlag, "tls-cert", "", "Path to TLS certificate for sidecar API")

--- a/development/kind/run-local-node.sh
+++ b/development/kind/run-local-node.sh
@@ -36,4 +36,5 @@ exec ./bin/sam-node run \
   --bind-addr 127.0.0.1:9099 \
   --api-token devtoken \
   --discovery-interval 200ms \
+  --hub-connect-timeout 10s \
   "$@"

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -678,7 +678,7 @@ func (n *SamNode) ConnectAndAuthWithHub(ctx context.Context, addr multiaddr.Mult
 		}
 
 		// Create a per-replica timeout context to prevent blocking on offline replicas
-		replicaCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		replicaCtx, cancel := context.WithTimeout(ctx, n.config.HubConnectTimeout)
 
 		if err := n.Host.Connect(replicaCtx, *addrInfo); err != nil {
 			cancel()

--- a/internal/node/options.go
+++ b/internal/node/options.go
@@ -28,6 +28,7 @@ const (
 	DefaultDiscoveryInterval = "30s"
 	DefaultHubURL            = "http://localhost:8080"
 	DefaultConfigFile        = "sam-node.yaml"
+	DefaultHubConnectTimeout = 5 * time.Second
 )
 
 // Options holds all configuration options for a SamNode.
@@ -48,6 +49,8 @@ type Options struct {
 	AutoRelayMinInterval time.Duration
 	AutoRelayBootDelay   time.Duration
 	AutoRelayBackoff     time.Duration
+	// HubConnectTimeout bounds each hub address's dial (connect + stream open).
+	HubConnectTimeout time.Duration
 
 	BiscuitTimeout time.Duration
 }
@@ -74,6 +77,9 @@ func (o *Options) Default() {
 	}
 	if o.KeyGracePeriod == 0 {
 		o.KeyGracePeriod = 24 * time.Hour
+	}
+	if o.HubConnectTimeout == 0 {
+		o.HubConnectTimeout = DefaultHubConnectTimeout
 	}
 	if len(o.ListenAddrs) == 0 {
 		o.ListenAddrs = []string{"/ip4/0.0.0.0/udp/5001/quic-v1", "/ip4/0.0.0.0/tcp/5002"}


### PR DESCRIPTION
ConnectAndAuthWithHub bounded each hub address dial to a hard-coded 5s. Add HubConnectTimeout (default 5s) exposed via `--hub-connect-timeout` on run and join. The kind-local-node script sets it to 10s, since dialing the hub through the NodePort/kube-proxy path is slower than 5s.