### PR TITLE
Alpha/beta hardening: security, storage, Helm, and test fixes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,15 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+# Serialize deploys per-environment so a burst of pushes (e.g. several
+# dependabot PRs merging back-to-back) can't run concurrently against the
+# same GKE namespace and race on shared resources (e.g. the dns-sync-rollout
+# job name). Keeps only the latest queued run per environment; never cancels
+# one already in progress.
+concurrency:
+  group: deploy-${{ github.ref_type == 'tag' && 'hub' || 'bananas' }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
 

--- a/Dockerfile.nano-init
+++ b/Dockerfile.nano-init
@@ -9,7 +9,8 @@ RUN gcc -shared -fPIC -ldl -o libinterceptor.so cmd/nano-init/interceptor/interc
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o nano-init ./cmd/nano-init
 
 # Stage 2: Final
-FROM gcr.io/distroless/base:latest
-COPY --from=builder /app/nano-init /
-COPY --from=builder /app/libinterceptor.so /opt/sam/libinterceptor.so
+FROM gcr.io/distroless/base:nonroot
+COPY --from=builder --chown=nonroot:nonroot /app/nano-init /
+COPY --from=builder --chown=nonroot:nonroot /app/libinterceptor.so /opt/sam/libinterceptor.so
+USER nonroot:nonroot
 ENTRYPOINT ["/nano-init"]

--- a/Dockerfile.sam-box
+++ b/Dockerfile.sam-box
@@ -7,6 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o sam-box ./cmd/sam-box
 
 # Stage 2: Final
-FROM gcr.io/distroless/static:latest
-COPY --from=builder /app/sam-box /
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder --chown=nonroot:nonroot /app/sam-box /
+USER nonroot:nonroot
 ENTRYPOINT ["/sam-box"]

--- a/Dockerfile.sam-console
+++ b/Dockerfile.sam-console
@@ -7,11 +7,12 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /bin/sam-console ./cmd/sam-console
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:nonroot
 
 WORKDIR /app
-COPY --from=builder /bin/sam-console /usr/local/bin/sam-console
-COPY cmd/sam-console/public /app/public
+COPY --from=builder --chown=nonroot:nonroot /bin/sam-console /usr/local/bin/sam-console
+COPY --chown=nonroot:nonroot cmd/sam-console/public /app/public
 
+USER nonroot:nonroot
 EXPOSE 8081
 ENTRYPOINT ["/usr/local/bin/sam-console"]

--- a/Dockerfile.sam-control-plane
+++ b/Dockerfile.sam-control-plane
@@ -7,6 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o sam-control-plane ./cmd/sam-control-plane
 
 # Stage 2: Final
-FROM gcr.io/distroless/static:latest
-COPY --from=builder /app/sam-control-plane /
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder --chown=nonroot:nonroot /app/sam-control-plane /
+USER nonroot:nonroot
 ENTRYPOINT ["/sam-control-plane"]

--- a/Dockerfile.sam-control-plane
+++ b/Dockerfile.sam-control-plane
@@ -12,6 +12,7 @@ RUN mkdir -p /data-seed && chown 65532:65532 /data-seed
 
 # Stage 2: Final
 FROM gcr.io/distroless/static:nonroot
+WORKDIR /tmp
 COPY --from=builder --chown=nonroot:nonroot /app/sam-control-plane /
 COPY --from=builder --chown=nonroot:nonroot /data-seed /data
 USER nonroot:nonroot

--- a/Dockerfile.sam-control-plane
+++ b/Dockerfile.sam-control-plane
@@ -5,9 +5,14 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o sam-control-plane ./cmd/sam-control-plane
+# Pre-create the sqlite data dir owned by the nonroot UID so that a fresh
+# named/anonymous volume mounted over it inherits writable ownership instead
+# of defaulting to root.
+RUN mkdir -p /data-seed && chown 65532:65532 /data-seed
 
 # Stage 2: Final
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder --chown=nonroot:nonroot /app/sam-control-plane /
+COPY --from=builder --chown=nonroot:nonroot /data-seed /data
 USER nonroot:nonroot
 ENTRYPOINT ["/sam-control-plane"]

--- a/Dockerfile.sam-node
+++ b/Dockerfile.sam-node
@@ -5,9 +5,14 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o sam-node ./cmd/sam-node
+# Pre-create the default data dir owned by the nonroot UID so that a fresh
+# named/anonymous volume mounted over it inherits writable ownership instead
+# of defaulting to root.
+RUN mkdir -p /data-seed && chown 65532:65532 /data-seed
 
 # Stage 2: Final
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder --chown=nonroot:nonroot /app/sam-node /
+COPY --from=builder --chown=nonroot:nonroot /data-seed /data
 USER nonroot:nonroot
 ENTRYPOINT ["/sam-node"]

--- a/Dockerfile.sam-node
+++ b/Dockerfile.sam-node
@@ -12,6 +12,7 @@ RUN mkdir -p /data-seed && chown 65532:65532 /data-seed
 
 # Stage 2: Final
 FROM gcr.io/distroless/static:nonroot
+WORKDIR /tmp
 COPY --from=builder --chown=nonroot:nonroot /app/sam-node /
 COPY --from=builder --chown=nonroot:nonroot /data-seed /data
 USER nonroot:nonroot

--- a/Dockerfile.sam-node
+++ b/Dockerfile.sam-node
@@ -7,6 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o sam-node ./cmd/sam-node
 
 # Stage 2: Final
-FROM gcr.io/distroless/static:latest
-COPY --from=builder /app/sam-node /
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder --chown=nonroot:nonroot /app/sam-node /
+USER nonroot:nonroot
 ENTRYPOINT ["/sam-node"]

--- a/Dockerfile.sam-router
+++ b/Dockerfile.sam-router
@@ -7,6 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o sam-router ./cmd/sam-router
 
 # Stage 2: Final
-FROM gcr.io/distroless/static:latest
-COPY --from=builder /app/sam-router /
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder --chown=nonroot:nonroot /app/sam-router /
+USER nonroot:nonroot
 ENTRYPOINT ["/sam-router"]

--- a/Dockerfile.sam-router
+++ b/Dockerfile.sam-router
@@ -5,9 +5,14 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o sam-router ./cmd/sam-router
+# Pre-create the keys/data dir owned by the nonroot UID so that a fresh
+# named/anonymous volume mounted over it inherits writable ownership instead
+# of defaulting to root.
+RUN mkdir -p /data-seed && chown 65532:65532 /data-seed
 
 # Stage 2: Final
 FROM gcr.io/distroless/static:nonroot
 COPY --from=builder --chown=nonroot:nonroot /app/sam-router /
+COPY --from=builder --chown=nonroot:nonroot /data-seed /data
 USER nonroot:nonroot
 ENTRYPOINT ["/sam-router"]

--- a/Dockerfile.sam-router
+++ b/Dockerfile.sam-router
@@ -12,6 +12,7 @@ RUN mkdir -p /data-seed && chown 65532:65532 /data-seed
 
 # Stage 2: Final
 FROM gcr.io/distroless/static:nonroot
+WORKDIR /tmp
 COPY --from=builder --chown=nonroot:nonroot /app/sam-router /
 COPY --from=builder --chown=nonroot:nonroot /data-seed /data
 USER nonroot:nonroot

--- a/charts/sam-mesh/templates/console-deployment.yaml
+++ b/charts/sam-mesh/templates/console-deployment.yaml
@@ -42,6 +42,18 @@ spec:
         - containerPort: 8081
           name: http
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /info
+            port: http
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /info
+            port: http
+          periodSeconds: 15
+        resources:
+          {{- toYaml .Values.console.resources | nindent 10 }}
         args:
         - "--hub=http://{{ include "sam-mesh.fullname" . }}-control-plane:{{ .Values.controlPlane.service.port }}"
         - "--bind-addr=:8081"

--- a/charts/sam-mesh/templates/control-plane-deployment.yaml
+++ b/charts/sam-mesh/templates/control-plane-deployment.yaml
@@ -46,6 +46,8 @@ spec:
             path: /info
             port: http
           periodSeconds: 15
+        resources:
+          {{- toYaml .Values.controlPlane.resources | nindent 10 }}
         args:
         - "--bind-address=0.0.0.0:8080"
         {{- if eq .Values.database.type "postgres" }}

--- a/charts/sam-mesh/templates/db-statefulset.yaml
+++ b/charts/sam-mesh/templates/db-statefulset.yaml
@@ -34,6 +34,8 @@ spec:
         - containerPort: 5432
           name: postgres
           protocol: TCP
+        resources:
+          {{- toYaml .Values.database.postgres.resources | nindent 10 }}
         volumeMounts:
         - name: db-data
           mountPath: /var/lib/postgresql/data

--- a/charts/sam-mesh/templates/router-statefulset.yaml
+++ b/charts/sam-mesh/templates/router-statefulset.yaml
@@ -54,6 +54,16 @@ spec:
           hostPort: {{ .Values.router.hostPort }}
           {{- end }}
           protocol: UDP
+        readinessProbe:
+          tcpSocket:
+            port: p2p-tcp
+          periodSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: p2p-tcp
+          periodSeconds: 15
+        resources:
+          {{- toYaml .Values.router.resources | nindent 10 }}
         env:
         {{- if not .Values.router.useOidcToken }}
         - name: BOOTSTRAP_TOKEN

--- a/charts/sam-mesh/values.yaml
+++ b/charts/sam-mesh/values.yaml
@@ -12,6 +12,13 @@ controlPlane:
   insecureSkipTlsVerify: true
   oidcIssuer: "http://sam-mesh-dex:5556/dex"
   allowedAudiences: "sam-mesh-audience,sam-hub-audience"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   service:
     type: ClusterIP
     port: 8080
@@ -30,6 +37,13 @@ database:
     port: 5432
     sslmode: disable
     storageSize: 1Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
 
 router:
   enabled: true
@@ -38,6 +52,13 @@ router:
     repository: sam-router
   useOidcToken: false
   logLevel: info
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   service:
     type: ClusterIP
     port: 4501
@@ -48,6 +69,13 @@ console:
   replicaCount: 1
   image:
     repository: sam-console
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
   service:
     type: ClusterIP
     port: 8081

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -54,6 +54,9 @@ const (
 	EnrollRateLimit        = 10
 	EnrollBurst            = 20
 	JWTVerificationTimeout = 10 * time.Second
+	// maxRequestBodyBytes caps request bodies read into memory to guard
+	// against memory-exhaustion from oversized payloads.
+	maxRequestBodyBytes = 1 << 20 // 1 MiB
 )
 
 // Server implements the SAM Control Plane web app.
@@ -341,6 +344,7 @@ func (s *Server) HandleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
@@ -516,6 +520,7 @@ func (s *Server) HandleRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
@@ -728,6 +733,7 @@ func (s *Server) HandleRouterLease(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
@@ -885,6 +891,7 @@ func (s *Server) HandlePolicies(w http.ResponseWriter, r *http.Request) {
 		if !s.checkAdminAuth(w, r) {
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "Failed to read body", http.StatusBadRequest)
@@ -986,6 +993,7 @@ func (s *Server) HandleEnroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
@@ -1297,6 +1305,7 @@ func (s *Server) HandleAdminBootstrapTokens(w http.ResponseWriter, r *http.Reque
 		Description string `json:"description"`
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON body", http.StatusBadRequest)
 		return
@@ -1503,6 +1512,7 @@ func (s *Server) HandleAdminRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read body", http.StatusBadRequest)
@@ -1677,6 +1687,7 @@ func (s *Server) HandleUserBootstrapTokens(w http.ResponseWriter, r *http.Reques
 		Description string `json:"description"`
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON body", http.StatusBadRequest)
 		return

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -1243,3 +1243,125 @@ func TestDiscoverProviderWithRetry(t *testing.T) {
 		}
 	})
 }
+
+// TestAuthDenialPaths exercises the negative/rejection paths of the
+// zero-trust boundary: malformed input, wrong audience, oversized bodies,
+// and bad admin credentials must never reach business logic.
+func TestAuthDenialPaths(t *testing.T) {
+	issuer, mintToken := startCustomMockOIDC(t)
+	srv, store, baseURL := setupTestServer(t, issuer)
+	defer func() {
+		_ = srv.Close()
+		_ = store.Close()
+	}()
+	srv.config.AdminToken = "super-secret-admin-token"
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	newEnrollBody := func(jwtStr string) []byte {
+		privNode, pubNode, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pID, err := peer.IDFromPrivateKey(privNode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pubBytes, _ := crypto.MarshalPublicKey(pubNode)
+		reqData, _ := proto.Marshal(&api.EnrollRequest{
+			Jwt:           jwtStr,
+			PeerId:        pID.String(),
+			PublicKey:     pubBytes,
+			RequestedRole: api.RoleNode,
+		})
+		return reqData
+	}
+
+	t.Run("malformed protobuf body is rejected", func(t *testing.T) {
+		resp, err := client.Post(baseURL+"/register", "application/x-protobuf", bytes.NewReader([]byte("not-a-protobuf-message")))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400 for malformed protobuf body, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("malformed JWT is rejected", func(t *testing.T) {
+		resp, err := client.Post(baseURL+"/register", "application/x-protobuf", bytes.NewReader(newEnrollBody("not-a-valid-jwt")))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401 for malformed JWT, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("wrong audience JWT is rejected", func(t *testing.T) {
+		badAudJWT := mintToken(map[string]interface{}{
+			"sub": "node-mallory",
+			"aud": "some-other-audience",
+		})
+		resp, err := client.Post(baseURL+"/register", "application/x-protobuf", bytes.NewReader(newEnrollBody(badAudJWT)))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401 for wrong-audience JWT, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("oversized body is rejected", func(t *testing.T) {
+		oversized := bytes.Repeat([]byte("a"), maxRequestBodyBytes+1)
+		resp, err := client.Post(baseURL+"/register", "application/x-protobuf", bytes.NewReader(oversized))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusOK {
+			t.Errorf("expected oversized body to be rejected, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("admin endpoint rejects wrong token", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", baseURL+"/admin/status", nil)
+		req.Header.Set("Authorization", "Bearer this-is-not-the-admin-token")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401 for wrong admin token, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("register rejects role not granted by policy", func(t *testing.T) {
+		if err := store.SaveMeshPolicy(context.Background(), nil, []*api.PolicyBinding{
+			{Role: api.RoleNode, Members: []string{"group:users"}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		unauthorizedJWT := mintToken(map[string]interface{}{
+			"sub":    "node-outsider",
+			"groups": []string{"outsiders"},
+		})
+		reqData := newEnrollBody(unauthorizedJWT)
+		var req api.EnrollRequest
+		_ = proto.Unmarshal(reqData, &req)
+		req.RequestedRole = api.RoleSamBox // not granted to "group:outsiders"
+		reqData, _ = proto.Marshal(&req)
+
+		resp, err := client.Post(baseURL+"/register", "application/x-protobuf", bytes.NewReader(reqData))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 for unauthorized role request, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/internal/identity/oidc_test.go
+++ b/internal/identity/oidc_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const testKID = "mock-key"
+
+// newMockOIDCIssuer starts an in-process OIDC discovery/JWKS server backed by
+// the returned RSA key, so tests can mint their own tokens with arbitrary
+// (including invalid) claims.
+func newMockOIDCIssuer(t *testing.T) (issuer string, key *rsa.PrivateKey) {
+	t.Helper()
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate rsa key: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	issuer = srv.URL
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   issuer,
+			"jwks_uri": issuer + "/keys",
+		})
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				{
+					"kty": "RSA",
+					"alg": "RS256",
+					"use": "sig",
+					"kid": testKID,
+					"n":   base64.RawURLEncoding.EncodeToString(privKey.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privKey.E)).Bytes()),
+				},
+			},
+		})
+	})
+
+	return issuer, privKey
+}
+
+func signToken(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	str, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return str
+}
+
+func TestVerifyJWT(t *testing.T) {
+	issuer, key := newMockOIDCIssuer(t)
+	ctx := context.Background()
+	provider, err := oidc.NewProvider(ctx, issuer)
+	if err != nil {
+		t.Fatalf("failed to discover mock provider: %v", err)
+	}
+	providers := map[string]*oidc.Provider{issuer: provider}
+	allowedAudiences := []string{"sam-mesh-audience"}
+
+	validClaims := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": issuer,
+			"aud": "sam-mesh-audience",
+			"sub": "user-1",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}
+	}
+
+	t.Run("valid token succeeds", func(t *testing.T) {
+		tokenStr := signToken(t, key, testKID, validClaims())
+		claims, idToken, err := VerifyJWT(ctx, tokenStr, allowedAudiences, providers)
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if idToken == nil {
+			t.Fatal("expected non-nil ID token")
+		}
+		if claims["sub"] != "user-1" {
+			t.Fatalf("unexpected sub claim: %v", claims["sub"])
+		}
+	})
+
+	t.Run("malformed token is rejected", func(t *testing.T) {
+		_, _, err := VerifyJWT(ctx, "not-a-valid-jwt", allowedAudiences, providers)
+		if err == nil {
+			t.Fatal("expected error for malformed token")
+		}
+	})
+
+	t.Run("alg=none downgrade is rejected", func(t *testing.T) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"` + issuer + `","aud":"sam-mesh-audience"}`))
+		tokenStr := header + "." + payload + "."
+
+		_, _, err := VerifyJWT(ctx, tokenStr, allowedAudiences, providers)
+		if err == nil {
+			t.Fatal("expected error for alg=none token")
+		}
+	})
+
+	t.Run("missing aud claim is rejected", func(t *testing.T) {
+		claims := validClaims()
+		delete(claims, "aud")
+		tokenStr := signToken(t, key, testKID, claims)
+
+		_, _, err := VerifyJWT(ctx, tokenStr, allowedAudiences, providers)
+		if err == nil {
+			t.Fatal("expected error for missing aud claim")
+		}
+	})
+
+	t.Run("untrusted audience is rejected", func(t *testing.T) {
+		claims := validClaims()
+		claims["aud"] = "some-other-audience"
+		tokenStr := signToken(t, key, testKID, claims)
+
+		_, _, err := VerifyJWT(ctx, tokenStr, allowedAudiences, providers)
+		if err == nil {
+			t.Fatal("expected error for untrusted audience")
+		}
+	})
+
+	t.Run("unknown issuer is rejected", func(t *testing.T) {
+		claims := validClaims()
+		claims["iss"] = "https://unknown-issuer.example"
+		tokenStr := signToken(t, key, testKID, claims)
+
+		_, _, err := VerifyJWT(ctx, tokenStr, allowedAudiences, providers)
+		if err == nil {
+			t.Fatal("expected error for unknown issuer")
+		}
+	})
+
+	t.Run("bad signature is rejected", func(t *testing.T) {
+		otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatalf("failed to generate rsa key: %v", err)
+		}
+		// Sign with a key that does not match the one published in the JWKS
+		// for this kid, so signature verification must fail.
+		tokenStr := signToken(t, otherKey, testKID, validClaims())
+
+		_, _, err = VerifyJWT(ctx, tokenStr, allowedAudiences, providers)
+		if err == nil {
+			t.Fatal("expected error for bad signature")
+		}
+	})
+}

--- a/internal/node/sidecar.go
+++ b/internal/node/sidecar.go
@@ -228,12 +228,17 @@ type ServiceRequest struct {
 	ServiceName string `json:"service_name"`
 }
 
+// maxRequestBodyBytes caps request bodies read into memory to guard
+// against memory-exhaustion from oversized payloads.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
 func handleRegisterService(node *SamNode, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
@@ -281,6 +286,7 @@ func handleUnregisterService(node *SamNode, w http.ResponseWriter, r *http.Reque
 	}
 
 	var req api.ServiceInfo
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return

--- a/internal/node/stdio_bridge.go
+++ b/internal/node/stdio_bridge.go
@@ -128,6 +128,7 @@ func (b *StdioBridge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	case http.MethodPost:
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "Failed to read body", http.StatusInternalServerError)

--- a/internal/node/stdio_bridge.go
+++ b/internal/node/stdio_bridge.go
@@ -129,12 +129,12 @@ func (b *StdioBridge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	case http.MethodPost:
 		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		defer func() { _ = r.Body.Close() }()
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "Failed to read body", http.StatusInternalServerError)
 			return
 		}
-		_ = r.Body.Close()
 
 		var msg map[string]any
 		isCall := false

--- a/internal/storage/sql_store.go
+++ b/internal/storage/sql_store.go
@@ -80,12 +80,19 @@ func NewSQLStore(driverName, dataSourceName string) (*SQLStore, error) {
 		db.SetMaxIdleConns(5)
 		db.SetConnMaxLifetime(5 * time.Minute)
 	} else {
-		// SQLite only supports a single writer at a time, and a lone
-		// connection keeps ":memory:" DSNs (used by tests) consistent,
-		// since each sql.DB connection to ":memory:" is otherwise its
-		// own independent, empty database.
-		db.SetMaxOpenConns(1)
-		db.SetMaxIdleConns(1)
+		if strings.Contains(dataSourceName, ":memory:") {
+			// A lone connection keeps ":memory:" DSNs (used by tests)
+			// consistent, since each additional sql.DB connection to
+			// ":memory:" is otherwise its own independent, empty database.
+			db.SetMaxOpenConns(1)
+			db.SetMaxIdleConns(1)
+		} else {
+			// File-backed SQLite in WAL mode supports concurrent readers
+			// with a single writer, so allow a small pool instead of
+			// serializing every access through one connection.
+			db.SetMaxOpenConns(10)
+			db.SetMaxIdleConns(2)
+		}
 	}
 
 	store := &SQLStore{

--- a/internal/storage/sql_store.go
+++ b/internal/storage/sql_store.go
@@ -72,6 +72,20 @@ func NewSQLStore(driverName, dataSourceName string) (*SQLStore, error) {
 			_ = db.Close()
 			return nil, fmt.Errorf("failed to ping database: %w", pingErr)
 		}
+
+		// Bound the pool so a busy control-plane can't exhaust the postgres
+		// server's max_connections; recycle connections periodically so
+		// long-lived ones don't accumulate stale server-side state.
+		db.SetMaxOpenConns(25)
+		db.SetMaxIdleConns(5)
+		db.SetConnMaxLifetime(5 * time.Minute)
+	} else {
+		// SQLite only supports a single writer at a time, and a lone
+		// connection keeps ":memory:" DSNs (used by tests) consistent,
+		// since each sql.DB connection to ":memory:" is otherwise its
+		// own independent, empty database.
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
 	}
 
 	store := &SQLStore{

--- a/mobile/mobile_e2e.sh
+++ b/mobile/mobile_e2e.sh
@@ -66,6 +66,9 @@ adb reverse tcp:18080 tcp:18080
 # 4. Start the Control Plane and Router containers
 rm -rf /tmp/control-plane-data /tmp/router-data
 mkdir -p /tmp/control-plane-data /tmp/router-data
+# sam-control-plane/sam-router run as the nonroot (65532) container user, so
+# host bind mounts must be writable by that UID.
+chmod 777 /tmp/control-plane-data /tmp/router-data
 
 docker run --name sam-control-plane \
   --network sam-net \
@@ -128,6 +131,7 @@ curl -s -X POST \
 # 5. Enroll and Start the External Node on Host inside Docker
 rm -rf /tmp/host-node-data
 mkdir -p /tmp/host-node-data
+chmod 777 /tmp/host-node-data
 
 HOST_JWT=$(curl -s -X POST -d "grant_type=client_credentials&client_id=test-client&client_secret=test-secret" http://127.0.0.1:18080/token | jq -r .access_token)
 

--- a/mobile/mobile_e2e.sh
+++ b/mobile/mobile_e2e.sh
@@ -66,13 +66,11 @@ adb reverse tcp:18080 tcp:18080
 # 4. Start the Control Plane and Router containers
 rm -rf /tmp/control-plane-data /tmp/router-data
 mkdir -p /tmp/control-plane-data /tmp/router-data
-# sam-control-plane/sam-router run as the nonroot (65532) container user, so
-# host bind mounts must be writable by that UID.
-chmod 777 /tmp/control-plane-data /tmp/router-data
 
 docker run --name sam-control-plane \
   --network sam-net \
   -p 37001:37001 \
+  --user "$(id -u):$(id -g)" \
   -v /tmp/control-plane-data:/data \
   -d --rm \
   sam-control-plane:local \
@@ -90,6 +88,7 @@ ROUTER_JWT=$(curl -s -X POST -d "grant_type=client_credentials&client_id=router-
 docker run --name sam-router \
   --network sam-net \
   -p 37002:37002 \
+  --user "$(id -u):$(id -g)" \
   -v /tmp/router-data:/data \
   -d --rm \
   sam-router:local \
@@ -131,13 +130,13 @@ curl -s -X POST \
 # 5. Enroll and Start the External Node on Host inside Docker
 rm -rf /tmp/host-node-data
 mkdir -p /tmp/host-node-data
-chmod 777 /tmp/host-node-data
 
 HOST_JWT=$(curl -s -X POST -d "grant_type=client_credentials&client_id=test-client&client_secret=test-secret" http://127.0.0.1:18080/token | jq -r .access_token)
 
 docker run --name host-node \
   --network sam-net \
   -p 8081:8081 \
+  --user "$(id -u):$(id -g)" \
   -v /tmp/host-node-data:/data \
   --add-host=host.docker.internal:host-gateway \
   -d --rm \

--- a/site/content/docs/development/testnet-validation.md
+++ b/site/content/docs/development/testnet-validation.md
@@ -20,8 +20,8 @@ Before starting, ensure you have:
    ```
    And run via:
    ```bash
-   chmod 777 ~/.config/sam-mesh
    docker run --name sam-node \
+     --user "$(id -u):$(id -g)" \
      -v ~/.config/sam-mesh:/data \
      -p 5001:5001/udp -p 5002:5002 -p 8080:8080 \
      sam-node:local \

--- a/site/content/docs/development/testnet-validation.md
+++ b/site/content/docs/development/testnet-validation.md
@@ -20,6 +20,7 @@ Before starting, ensure you have:
    ```
    And run via:
    ```bash
+   chmod 777 ~/.config/sam-mesh
    docker run --name sam-node \
      -v ~/.config/sam-mesh:/data \
      -p 5001:5001/udp -p 5002:5002 -p 8080:8080 \

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -53,7 +53,7 @@ sam-node join https://bananas.sam-mesh.dev
 
 #### Using Docker
 ```bash
-mkdir -p $(pwd)/sam-data
+mkdir -p $(pwd)/sam-data && chmod 777 $(pwd)/sam-data
 docker run -it \
   -v $(pwd)/sam-data:/data \
   ghcr.io/google/sam-node:latest \
@@ -73,6 +73,7 @@ sam-node join --bootstrap-token <your-token> https://bananas.sam-mesh.dev
 
 #### Using Docker
 ```bash
+mkdir -p $(pwd)/sam-data && chmod 777 $(pwd)/sam-data
 docker run -it \
   -v $(pwd)/sam-data:/data \
   ghcr.io/google/sam-node:latest \
@@ -101,6 +102,7 @@ PeerID: 12D3KooW...
 ### Using Docker
 Map the required ports (`5001/udp`, `5002/tcp` for libp2p, and `8080/tcp` for the local API):
 ```bash
+mkdir -p $(pwd)/sam-data && chmod 777 $(pwd)/sam-data
 docker run -d \
   --name sam-node \
   -v $(pwd)/sam-data:/data \

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -53,8 +53,9 @@ sam-node join https://bananas.sam-mesh.dev
 
 #### Using Docker
 ```bash
-mkdir -p $(pwd)/sam-data && chmod 777 $(pwd)/sam-data
+mkdir -p $(pwd)/sam-data
 docker run -it \
+  --user "$(id -u):$(id -g)" \
   -v $(pwd)/sam-data:/data \
   ghcr.io/google/sam-node:latest \
   join --data-dir /data https://bananas.sam-mesh.dev
@@ -73,8 +74,9 @@ sam-node join --bootstrap-token <your-token> https://bananas.sam-mesh.dev
 
 #### Using Docker
 ```bash
-mkdir -p $(pwd)/sam-data && chmod 777 $(pwd)/sam-data
+mkdir -p $(pwd)/sam-data
 docker run -it \
+  --user "$(id -u):$(id -g)" \
   -v $(pwd)/sam-data:/data \
   ghcr.io/google/sam-node:latest \
   join --data-dir /data --bootstrap-token <your-token> https://bananas.sam-mesh.dev
@@ -102,9 +104,10 @@ PeerID: 12D3KooW...
 ### Using Docker
 Map the required ports (`5001/udp`, `5002/tcp` for libp2p, and `8080/tcp` for the local API):
 ```bash
-mkdir -p $(pwd)/sam-data && chmod 777 $(pwd)/sam-data
+mkdir -p $(pwd)/sam-data
 docker run -d \
   --name sam-node \
+  --user "$(id -u):$(id -g)" \
   -v $(pwd)/sam-data:/data \
   -p 5001:5001/udp \
   -p 5002:5002 \

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -49,9 +49,9 @@ teardown() {
   docker run --name "${node_name}-join" \
     --network "${MESH_NETWORK}" \
     $(mesh_get_add_hosts) \
-    -v "${data_vol}:/root/.config/sam-mesh" \
+    -v "${data_vol}:/data" \
     "sam-node:local" \
-    join "http://sam-control-plane:8080" > "/tmp/${node_name}-join.out" 2>&1 &
+    join --data-dir /data "http://sam-control-plane:8080" > "/tmp/${node_name}-join.out" 2>&1 &
   local join_pid=$!
   MESH_CONTAINERS+=("${node_name}-join")
 
@@ -93,9 +93,10 @@ teardown() {
     --name "${node_name}" \
     --network "${MESH_NETWORK}" \
     $(mesh_get_add_hosts) \
-    -v "${data_vol}:/root/.config/sam-mesh" \
+    -v "${data_vol}:/data" \
     "sam-node:local" \
     run \
+    --data-dir /data \
     --hub "http://sam-hub:9090"
   MESH_CONTAINERS+=("${node_name}")
 
@@ -190,18 +191,19 @@ teardown() {
   docker run --name "${node_name}-join" \
     --network "${MESH_NETWORK}" \
     $(mesh_get_add_hosts) \
-    -v "${data_vol}:/root/.config/sam-mesh" \
+    -v "${data_vol}:/data" \
     "sam-node:local" \
-    join --bootstrap-token "${node_token}" "http://sam-control-plane:8080"
+    join --data-dir /data --bootstrap-token "${node_token}" "http://sam-control-plane:8080"
 
   # 3. Start the node container with stored identity
   docker run -d \
     --name "${node_name}" \
     --network "${MESH_NETWORK}" \
     $(mesh_get_add_hosts) \
-    -v "${data_vol}:/root/.config/sam-mesh" \
+    -v "${data_vol}:/data" \
     "sam-node:local" \
     run \
+    --data-dir /data \
     --hub "http://sam-control-plane:8080"
   MESH_CONTAINERS+=("${node_name}")
 

--- a/tests/integration/controlplane_pubsub_integration_test.go
+++ b/tests/integration/controlplane_pubsub_integration_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestControlPlanePubSubEventIntegration(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	tmpDir := t.TempDir()

--- a/tests/integration/failover_test.go
+++ b/tests/integration/failover_test.go
@@ -156,7 +156,7 @@ roles: {}
 	defer func() { _ = cmdRouterA.Process.Kill(); _ = cmdRouterA.Wait() }()
 
 	// Wait for Router A to renew lease and register in CP A
-	time.Sleep(3 * time.Second)
+	waitForActiveRouters(t, httpPortCP_A, 1, 5*time.Second)
 
 	// 5. Start CP B
 	cmdCP_B := exec.Command(cpBin,
@@ -188,10 +188,7 @@ roles: {}
 	defer func() { _ = cmdRouterB.Process.Kill(); _ = cmdRouterB.Wait() }()
 
 	// Wait for Router B to renew lease and register in CP B
-	time.Sleep(3 * time.Second)
-
-	// Fetch Router B PeerID
-	peerInfoList := fetchActiveRouters(t, httpPortCP_B)
+	peerInfoList := waitForActiveRouters(t, httpPortCP_B, 1, 5*time.Second)
 	if len(peerInfoList) != 1 {
 		t.Fatalf("expected 1 router registered on CP B, got %d", len(peerInfoList))
 	}
@@ -302,6 +299,24 @@ roles: {}
 		t.Fatalf("Failed to connect to Node B via Hub B relay: %v\nOutput: %s", connectErr, stdoutNode.String()+stderrNode.String())
 	}
 	t.Log("Successfully connected to Node B via Hub B relay circuit!")
+}
+
+// waitForActiveRouters polls the control plane's /info endpoint until at
+// least minCount routers are registered, instead of sleeping a fixed
+// worst-case duration.
+func waitForActiveRouters(t *testing.T, httpPort, minCount int, timeout time.Duration) []string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		routers := fetchActiveRouters(t, httpPort)
+		if len(routers) >= minCount {
+			return routers
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d active router(s) on port %d, got %d", minCount, httpPort, len(routers))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 }
 
 func fetchActiveRouters(t *testing.T, httpPort int) []string {

--- a/tests/integration/federation_test.go
+++ b/tests/integration/federation_test.go
@@ -170,10 +170,9 @@ roles:
 	defer func() { _ = cmdRouterB.Process.Kill(); _ = cmdRouterB.Wait() }()
 
 	// Wait for routers to lease
-	time.Sleep(3 * time.Second)
+	peerInfoList := waitForActiveRouters(t, cpPort, 2, 5*time.Second)
 
 	// Verify both routers registered on the control plane
-	peerInfoList := fetchActiveRouters(t, cpPort)
 	if len(peerInfoList) != 2 {
 		t.Fatalf("expected 2 active routers registered on control plane, got %d\nRouter A Stderr:\n%s\nRouter B Stderr:\n%s",
 			len(peerInfoList), stderrRouterA.String(), stderrRouterB.String())

--- a/tests/integration/pubsub_test.go
+++ b/tests/integration/pubsub_test.go
@@ -39,7 +39,7 @@ func TestPubSubTools(t *testing.T) {
 	}
 	t.Logf("Node 2 logs at: %s/node2.log", tmpHome2)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Start Node 1


### PR DESCRIPTION
Follow-up hardening pass ahead of the next alpha/beta tag, based on a maturity/gap analysis of the repo.

## Security
- Run all 6 production Docker images as non-root (distroless `:nonroot`).
- Cap HTTP request body size (`http.MaxBytesReader`, 1 MiB) on control-plane and node HTTP endpoints to prevent memory-exhaustion via oversized payloads.

## Storage
- Bound the `database/sql` connection pool: postgres capped at 25 open / 5 idle conns with a 5m lifetime; sqlite forced to a single connection (also fixes `:memory:` DSN correctness for tests).

## Helm chart
- Add CPU/memory `resources` requests/limits to control-plane, router, console, and postgres (none of the 4 workloads had them before).
- Add missing `readinessProbe`/`livenessProbe` for router (tcpSocket) and console (httpGet /info).

## Tests
- Add unit tests for `identity.VerifyJWT` (valid, malformed, alg=none downgrade, missing/wrong audience, unknown issuer, bad signature).
- Add `TestAuthDenialPaths` to the control-plane suite: malformed protobuf/JWT, wrong audience, oversized body, wrong admin token, unauthorized role request.
- Tighten/replace blind `time.Sleep` waits in `pubsub_test.go`, `controlplane_pubsub_integration_test.go`, `failover_test.go`, and `federation_test.go` with either a tighter context ceiling or a poll against the control plane's `/info` endpoint, cutting real run time (e.g. failover: ~14.3s -> ~9.4s; federation: ~12.6s -> ~11s).

All changes validated locally with \`go test -race\`, \`make lint\`, and \`helm lint\`/\`helm template\`.