### PR TITLE
fix: check error from MarshalPrivateKey in GetOrGenerateKey

### DIFF
--- a/internal/node/enroll.go
+++ b/internal/node/enroll.go
@@ -43,7 +43,10 @@ func GetOrGenerateKey(s *Store) crypto.PrivKey {
 		if err != nil {
 			logger.Fatalf("Failed to generate key: %v", err)
 		}
-		raw, _ := crypto.MarshalPrivateKey(priv)
+		raw, err := crypto.MarshalPrivateKey(priv)
+		if err != nil {
+			logger.Fatalf("Failed to marshal private key: %v", err)
+		}
 		if err := s.SaveKey(raw); err != nil {
 			logger.Fatalf("Failed to save key: %v", err)
 		}


### PR DESCRIPTION
If marshalling fails, the returned bytes are nil/empty. Saving that to the store silently corrupts the key, causing a fatal error on next startup.