### PR TITLE
fix: pass verified addresses to UpdateRelays on HTTP fallback reconnect

### DIFF
--- a/internal/node/connection_monitor.go
+++ b/internal/node/connection_monitor.go
@@ -91,7 +91,7 @@ func checkHubConnection(ctx context.Context, mgr hubConnectionManager) (stable b
 		}
 	}
 	if len(connectedAddrsFallback) > 0 {
-		mgr.UpdateRelays(newHubAddrs)
+		mgr.UpdateRelays(connectedAddrsFallback)
 		return false, true
 	}
 


### PR DESCRIPTION
connectedAddrsFallback contains only addresses that successfully connected; newHubAddrs includes all discovered addresses, verified or not.