### PR TITLE
fix(console): retry OIDC discovery instead of permanently disabling l…

### DIFF
--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -66,7 +66,7 @@ func NewServer(cfg Config) (*Server, error) {
 		}
 
 		if info.OidcIssuer != "" && info.ClientId != "" {
-			provider, err = oidc.NewProvider(context.Background(), info.OidcIssuer)
+			provider, err = discoverProviderWithRetry(context.Background(), info.OidcIssuer, oidcDiscoveryMaxAttempts, oidcDiscoveryBaseDelay, oidcDiscoveryMaxDelay)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed OIDC discovery on %s: %v\n", info.OidcIssuer, err)
 			} else if provider.Endpoint().AuthURL != "" && provider.Endpoint().TokenURL != "" {
@@ -84,7 +84,6 @@ func NewServer(cfg Config) (*Server, error) {
 		provider: provider,
 		clientID: clientID,
 	}
-
 	// Create reverse proxy to the control plane
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
@@ -125,6 +124,43 @@ func NewServer(cfg Config) (*Server, error) {
 	s.mux.HandleFunc("/info", s.HandleInfo)
 
 	return s, nil
+}
+
+// Defaults for discoverProviderWithRetry; matches sam-control-plane's
+// discoverProviders so a transient hiccup during rollout (e.g. Dex still
+// starting up) doesn't permanently disable console OIDC login, since the
+// console's /info reports healthy either way and Kubernetes won't restart it.
+const (
+	oidcDiscoveryMaxAttempts = 5
+	oidcDiscoveryBaseDelay   = 1 * time.Second
+	oidcDiscoveryMaxDelay    = 8 * time.Second
+)
+
+// discoverProviderWithRetry retries OIDC discovery with exponential backoff so a
+// transient upstream hiccup (e.g. the identity provider mid-rollout) doesn't
+// permanently disable the console's OIDC login endpoints.
+func discoverProviderWithRetry(ctx context.Context, issuer string, maxAttempts int, baseDelay, maxDelay time.Duration) (*oidc.Provider, error) {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			delay := baseDelay * time.Duration(1<<uint(attempt-1))
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		provider, err := oidc.NewProvider(ctx, issuer)
+		if err == nil {
+			return provider, nil
+		}
+		lastErr = err
+		fmt.Fprintf(os.Stderr, "Warning: OIDC discovery attempt %d/%d for %s failed: %v\n", attempt+1, maxAttempts, issuer, err)
+	}
+	return nil, lastErr
 }
 
 func (s *Server) Handler() http.Handler {

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -66,7 +66,10 @@ func NewServer(cfg Config) (*Server, error) {
 		}
 
 		if info.OidcIssuer != "" && info.ClientId != "" {
-			provider, err = discoverProviderWithRetry(context.Background(), info.OidcIssuer, oidcDiscoveryMaxAttempts, oidcDiscoveryBaseDelay, oidcDiscoveryMaxDelay)
+			// Bound the discovery client so an unresponsive issuer can't hang startup.
+			oidcClient := &http.Client{Timeout: 10 * time.Second}
+			discoveryCtx := oidc.ClientContext(context.Background(), oidcClient)
+			provider, err = discoverProviderWithRetry(discoveryCtx, info.OidcIssuer, oidcDiscoveryMaxAttempts, oidcDiscoveryBaseDelay, oidcDiscoveryMaxDelay)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed OIDC discovery on %s: %v\n", info.OidcIssuer, err)
 			} else if provider.Endpoint().AuthURL != "" && provider.Endpoint().TokenURL != "" {
@@ -267,7 +270,9 @@ func (s *Server) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		Scopes:      []string{oidc.ScopeOpenID, "profile", "email"},
 	}
 
-	oauth2Token, err := oauth2Config.Exchange(r.Context(), code,
+	exchangeCtx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	oauth2Token, err := oauth2Config.Exchange(exchangeCtx, code,
 		oauth2.SetAuthURLParam("code_verifier", verifierCookie.Value),
 	)
 	if err != nil {

--- a/internal/console/server_test.go
+++ b/internal/console/server_test.go
@@ -5,12 +5,14 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/google/sam/api"
 	"google.golang.org/protobuf/proto"
 )
@@ -202,6 +204,42 @@ func TestDiscoverProviderWithRetry(t *testing.T) {
 
 		if _, err := discoverProviderWithRetry(context.Background(), srv.URL, 3, time.Millisecond, 5*time.Millisecond); err == nil {
 			t.Fatal("expected discovery to fail after exhausting retries")
+		}
+	})
+
+	// A hung connection (issuer accepts but never responds) must not block
+	// discovery forever: the client attached via oidc.ClientContext needs its
+	// own timeout, since neither the retry loop nor context.Background() bound
+	// a single attempt's duration on their own.
+	t.Run("does not hang on an unresponsive issuer", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to listen: %v", err)
+		}
+		defer func() { _ = ln.Close() }()
+		go func() {
+			for {
+				conn, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				_ = conn // accepted but deliberately never responds, to simulate a hang
+			}
+		}()
+
+		client := &http.Client{Timeout: 50 * time.Millisecond}
+		ctx := oidc.ClientContext(context.Background(), client)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			_, _ = discoverProviderWithRetry(ctx, "http://"+ln.Addr().String(), 2, time.Millisecond, 5*time.Millisecond)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("discoverProviderWithRetry hung on an unresponsive issuer instead of timing out")
 		}
 	})
 }

--- a/internal/console/server_test.go
+++ b/internal/console/server_test.go
@@ -1,12 +1,15 @@
 package console
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/sam/api"
 	"google.golang.org/protobuf/proto"
@@ -95,4 +98,110 @@ func TestNewServer_OIDCAutoDiscovery(t *testing.T) {
 	if srv.provider.Endpoint().AuthURL != serverURL+"/auth" {
 		t.Errorf("expected AuthURL '%s', got '%s'", serverURL+"/auth", srv.provider.Endpoint().AuthURL)
 	}
+}
+
+// TestNewServer_OIDCDiscoveryRetriesTransientFailure guards against a real
+// deployment race: if the OIDC issuer (e.g. Dex) is still starting up when
+// sam-console boots, discovery must retry instead of permanently disabling
+// login for the life of the pod (console's /info reports healthy either way,
+// so Kubernetes never restarts it to retry on its own).
+func TestNewServer_OIDCDiscoveryRetriesTransientFailure(t *testing.T) {
+	var attempts int32
+	var serverURL string
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/info", func(w http.ResponseWriter, r *http.Request) {
+		resp := &api.ControlPlaneInfoResponse{
+			OidcIssuer: serverURL,
+			ClientId:   "mock-console-client",
+		}
+		data, err := proto.Marshal(resp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	})
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			http.Error(w, "upstream connect error", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 serverURL,
+			"authorization_endpoint": serverURL + "/auth",
+			"token_endpoint":         serverURL + "/token",
+			"jwks_uri":               serverURL + "/keys",
+		})
+	})
+
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []map[string]any{}})
+	})
+
+	mockSrv := httptest.NewServer(mux)
+	defer mockSrv.Close()
+	serverURL = mockSrv.URL
+
+	srv, err := NewServer(Config{
+		ControlPlaneURL: serverURL,
+		AdminToken:      "test-admin-token",
+		StaticDir:       t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+	if srv.provider == nil {
+		t.Fatal("expected OIDC discovery to succeed after transient failures, provider is nil")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected discovery to take 3 attempts, got %d", got)
+	}
+}
+
+func TestDiscoverProviderWithRetry(t *testing.T) {
+	t.Run("succeeds after transient failures", func(t *testing.T) {
+		var attempts int32
+		mux := http.NewServeMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+		issuer := srv.URL
+
+		mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+			if atomic.AddInt32(&attempts, 1) < 3 {
+				http.Error(w, "upstream connect error", http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":   issuer,
+				"jwks_uri": issuer + "/keys",
+			})
+		})
+
+		if _, err := discoverProviderWithRetry(context.Background(), issuer, 5, time.Millisecond, 5*time.Millisecond); err != nil {
+			t.Fatalf("expected discovery to eventually succeed, got: %v", err)
+		}
+		if got := atomic.LoadInt32(&attempts); got != 3 {
+			t.Errorf("expected 3 attempts, got %d", got)
+		}
+	})
+
+	t.Run("gives up after max attempts", func(t *testing.T) {
+		mux := http.NewServeMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "always down", http.StatusServiceUnavailable)
+		})
+
+		if _, err := discoverProviderWithRetry(context.Background(), srv.URL, 3, time.Millisecond, 5*time.Millisecond); err == nil {
+			t.Fatal("expected discovery to fail after exhausting retries")
+		}
+	})
 }

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -845,7 +845,7 @@ func (s *Server) HandleRouterLease(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Enforce role("router") or role("bootstrap") inside the biscuit
-	authorizer, err := b.Authorizer(verifyingKey)
+	authorizer, err := b.Authorizer(verifyingKey, identity.AuthorizerOptions(s.config.BiscuitTimeout)...)
 	if err != nil {
 		http.Error(w, "Internal authorizer error", http.StatusInternalServerError)
 		return

--- a/internal/identity/biscuit.go
+++ b/internal/identity/biscuit.go
@@ -31,6 +31,22 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+// DefaultAuthorizerTimeout bounds Datalog evaluation when no timeout is configured.
+// biscuit-go defaults to 2ms of wall-clock time, of which a single authorization of
+// a realistic token already spends ~0.14ms (~1.1ms under -race), so ordinary
+// scheduling noise turns into a spurious denial. The amount of work is bounded by
+// the fact and iteration limits; this deadline only caps how long the caller waits.
+const DefaultAuthorizerTimeout = 1 * time.Second
+
+// AuthorizerOptions returns the authorizer options enforcing a Datalog evaluation
+// budget. A non-positive timeout falls back to DefaultAuthorizerTimeout.
+func AuthorizerOptions(timeout time.Duration) []biscuit.AuthorizerOption {
+	if timeout <= 0 {
+		timeout = DefaultAuthorizerTimeout
+	}
+	return []biscuit.AuthorizerOption{biscuit.WithWorldOptions(datalog.WithMaxDuration(timeout))}
+}
+
 // MintBiscuitToken generates a signed Biscuit token for a peer with policy rules based on JWT claims.
 // labels are control-plane-attested key=value claims (canonical, pre-validated); empty means no claims.
 func MintBiscuitToken(signingKey ed25519.PrivateKey, claims jwt.MapClaims, token *oidc.IDToken, remotePeer peer.ID, biscuitExpiry time.Time, roles []string, policyRoles []*api.PolicyRole, labels map[string]string) ([]byte, []string, error) {
@@ -225,10 +241,7 @@ func VerifyBiscuitAndGetKey(biscuitData []byte, expectedPeer peer.ID, trustedPub
 		return nil, nil, fmt.Errorf("malformed biscuit: %w", err)
 	}
 
-	var authOpts []biscuit.AuthorizerOption
-	if timeout > 0 {
-		authOpts = append(authOpts, biscuit.WithWorldOptions(datalog.WithMaxDuration(timeout)))
-	}
+	authOpts := AuthorizerOptions(timeout)
 
 	var lastErr error
 	var authorized bool
@@ -356,10 +369,7 @@ func VerifyAndExtractPeerID(trustedPublicKeys []ed25519.PublicKey, biscuitData [
 		return "", fmt.Errorf("malformed biscuit: %w", err)
 	}
 
-	var authOpts []biscuit.AuthorizerOption
-	if timeout > 0 {
-		authOpts = append(authOpts, biscuit.WithWorldOptions(datalog.WithMaxDuration(timeout)))
-	}
+	authOpts := AuthorizerOptions(timeout)
 
 	var authorizer biscuit.Authorizer
 	var verified bool
@@ -420,13 +430,13 @@ func VerifyAndExtractPeerID(trustedPublicKeys []ed25519.PublicKey, biscuitData [
 
 // VerifyBiscuitRole checks that the biscuit is signed by the control plane's public key
 // and contains the specified role fact.
-func VerifyBiscuitRole(biscuitData []byte, controlPlanePubKey ed25519.PublicKey, expectedRole string) error {
+func VerifyBiscuitRole(biscuitData []byte, controlPlanePubKey ed25519.PublicKey, expectedRole string, timeout time.Duration) error {
 	b, err := biscuit.Unmarshal(biscuitData)
 	if err != nil {
 		return fmt.Errorf("malformed biscuit: %w", err)
 	}
 
-	authorizer, err := b.Authorizer(controlPlanePubKey)
+	authorizer, err := b.Authorizer(controlPlanePubKey, AuthorizerOptions(timeout)...)
 	if err != nil {
 		return fmt.Errorf("failed to create authorizer: %w", err)
 	}

--- a/internal/identity/biscuit_test.go
+++ b/internal/identity/biscuit_test.go
@@ -17,6 +17,7 @@ package identity
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -572,5 +573,38 @@ func TestVerifyAndExtractPeerID_MultipleTrustedKeys(t *testing.T) {
 
 	if extractedPeer != dummyPeer {
 		t.Errorf("expected peer ID %s, got %s", dummyPeer, extractedPeer)
+	}
+}
+
+func TestVerifyBiscuitRole_TimeoutIsHonored(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privNode, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dummyPeer, err := peer.IDFromPrivateKey(privNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	biscuitData, err := MintBootstrapBiscuitToken(priv, dummyPeer, api.RoleRouter, time.Now().Add(1*time.Hour), nil, nil)
+	if err != nil {
+		t.Fatalf("MintBootstrapBiscuitToken failed: %v", err)
+	}
+
+	// A zero timeout must fall back to the generous default, not to the 2ms
+	// biscuit-go default which spuriously fails under load.
+	if err := VerifyBiscuitRole(biscuitData, pub, api.RoleRouter, 0); err != nil {
+		t.Errorf("VerifyBiscuitRole with zero timeout failed: %v", err)
+	}
+
+	// An explicit timeout must reach the Datalog world.
+	err = VerifyBiscuitRole(biscuitData, pub, api.RoleRouter, time.Nanosecond)
+	if !errors.Is(err, datalog.ErrWorldRunLimitTimeout) {
+		t.Errorf("expected datalog timeout error, got %v", err)
 	}
 }

--- a/internal/node/enroll.go
+++ b/internal/node/enroll.go
@@ -136,7 +136,7 @@ func (n *SamNode) processEnrollResponse(resp *http.Response) (*api.EnrollRespons
 	}
 
 	if n.config.RequiredRole != "" {
-		if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, ed25519.PublicKey(enrollResp.ControlPlanePublicKey), n.config.RequiredRole); err != nil {
+		if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, ed25519.PublicKey(enrollResp.ControlPlanePublicKey), n.config.RequiredRole, n.BiscuitTimeout); err != nil {
 			return nil, fmt.Errorf("enrolled biscuit token lacks required role %q: %w", n.config.RequiredRole, err)
 		}
 	}
@@ -317,7 +317,7 @@ func (n *SamNode) EnrollBootstrap(ctx context.Context, controlPlaneURL string, b
 		return fmt.Errorf("received invalid control plane public key size: %d bytes", len(enrollResp.ControlPlanePublicKey))
 	}
 
-	if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, ed25519.PublicKey(enrollResp.ControlPlanePublicKey), n.config.RequiredRole); err != nil {
+	if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, ed25519.PublicKey(enrollResp.ControlPlanePublicKey), n.config.RequiredRole, n.BiscuitTimeout); err != nil {
 		return fmt.Errorf("enrolled biscuit token lacks required role %q: %w", n.config.RequiredRole, err)
 	}
 

--- a/internal/node/labels_gate.go
+++ b/internal/node/labels_gate.go
@@ -21,8 +21,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/biscuit-auth/biscuit-go/v2"
-	"github.com/biscuit-auth/biscuit-go/v2/datalog"
 	"github.com/google/sam/api"
 	"github.com/google/sam/internal/identity"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -106,11 +104,7 @@ func (n *SamNode) checkPeerLabels(providerBiscuit []byte, peerID peer.ID, requir
 		return fmt.Errorf("provider %s biscuit verification failed: %w", peerID, err)
 	}
 
-	var authOpts []biscuit.AuthorizerOption
-	if n.BiscuitTimeout > 0 {
-		authOpts = append(authOpts, biscuit.WithWorldOptions(datalog.WithMaxDuration(n.BiscuitTimeout)))
-	}
-	authorizer, err := b.Authorizer(key, authOpts...)
+	authorizer, err := b.Authorizer(key, identity.AuthorizerOptions(n.BiscuitTimeout)...)
 	if err != nil {
 		return fmt.Errorf("provider %s authorizer instantiation failed: %w", peerID, err)
 	}

--- a/internal/node/middleware.go
+++ b/internal/node/middleware.go
@@ -21,8 +21,8 @@ import (
 	"sync/atomic"
 
 	"github.com/biscuit-auth/biscuit-go/v2"
-	"github.com/biscuit-auth/biscuit-go/v2/datalog"
 	"github.com/google/sam/api"
+	"github.com/google/sam/internal/identity"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-msgio"
@@ -194,11 +194,7 @@ func (n *SamNode) Authorize(rawToken []byte, req RequestContext, pubKey ed25519.
 		return fmt.Errorf("invalid biscuit: %w", err)
 	}
 
-	var authOpts []biscuit.AuthorizerOption
-	if n.BiscuitTimeout > 0 {
-		authOpts = append(authOpts, biscuit.WithWorldOptions(datalog.WithMaxDuration(n.BiscuitTimeout)))
-	}
-	authorizer, err := b.Authorizer(pubKey, authOpts...)
+	authorizer, err := b.Authorizer(pubKey, identity.AuthorizerOptions(n.BiscuitTimeout)...)
 	if err != nil {
 		return err
 	}
@@ -340,10 +336,7 @@ func (n *SamNode) injectIdentityFacts(authorizer biscuit.Authorizer, pubKey ed25
 	copy(keys, n.trustedKeys)
 	n.keysMu.RUnlock()
 
-	var authOpts []biscuit.AuthorizerOption
-	if n.BiscuitTimeout > 0 {
-		authOpts = append(authOpts, biscuit.WithWorldOptions(datalog.WithMaxDuration(n.BiscuitTimeout)))
-	}
+	authOpts := identity.AuthorizerOptions(n.BiscuitTimeout)
 
 	var auth biscuit.Authorizer
 	var authErr error

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/biscuit-auth/biscuit-go/v2"
-	"github.com/biscuit-auth/biscuit-go/v2/datalog"
 	"github.com/google/sam/api"
 	"github.com/google/sam/internal/identity"
 	samdiscovery "github.com/google/sam/internal/node/discovery"
@@ -277,7 +276,7 @@ func (n *SamNode) Start(ctx context.Context) error {
 	if biscuitBytes := n.GetIdentity(); len(biscuitBytes) > 0 {
 		controlPlanePubKeyBytes, _, err := n.Store.LoadMeshConfig()
 		if err == nil && len(controlPlanePubKeyBytes) > 0 {
-			if err := identity.VerifyBiscuitRole(biscuitBytes, ed25519.PublicKey(controlPlanePubKeyBytes), n.config.RequiredRole); err != nil {
+			if err := identity.VerifyBiscuitRole(biscuitBytes, ed25519.PublicKey(controlPlanePubKeyBytes), n.config.RequiredRole, n.BiscuitTimeout); err != nil {
 				return fmt.Errorf("loaded identity fails role requirement %q: %w", n.config.RequiredRole, err)
 			}
 		}
@@ -829,7 +828,7 @@ func (n *SamNode) performRouterAuthHandshake(s network.Stream, biscuitBytes []by
 	}
 
 	// Enforce role("router") inside the biscuit
-	authorizer, err := b.Authorizer(trustedKeys[0])
+	authorizer, err := b.Authorizer(trustedKeys[0], identity.AuthorizerOptions(n.BiscuitTimeout)...)
 	if err != nil {
 		return false, fmt.Errorf("authorizer instantiation failed: %w", err)
 	}
@@ -1435,9 +1434,7 @@ func (n *SamNode) verifyBiscuit(biscuitData []byte, remotePeer peer.ID) (*biscui
 		if len(tk.Key) != ed25519.PublicKeySize {
 			continue
 		}
-		authorizer, err := b.Authorizer(tk.Key, biscuit.WithWorldOptions(
-			datalog.WithMaxDuration(5*time.Second),
-		))
+		authorizer, err := b.Authorizer(tk.Key, identity.AuthorizerOptions(n.BiscuitTimeout)...)
 		if err != nil {
 			lastErr = fmt.Errorf("authorizer error: %w", err)
 			continue

--- a/internal/node/oidc.go
+++ b/internal/node/oidc.go
@@ -302,9 +302,15 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 	return tokenResp.AccessToken, nil
 }
 
+// oidcDiscoveryTimeout bounds a single OIDC discovery HTTP call so an
+// unresponsive issuer can't hang "join"/"run --join" indefinitely. A var
+// (not const) so tests can shrink it instead of waiting out the real value.
+var oidcDiscoveryTimeout = 10 * time.Second
+
 // DiscoverTokenURL discovers the token URL from the OIDC issuer.
 func (n *SamNode) DiscoverTokenURL(ctx context.Context, issuerURL string) (string, error) {
-	provider, err := oidc.NewProvider(ctx, issuerURL)
+	client := &http.Client{Timeout: oidcDiscoveryTimeout}
+	provider, err := oidc.NewProvider(oidc.ClientContext(ctx, client), issuerURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to create OIDC provider: %w", err)
 	}
@@ -322,7 +328,8 @@ func (n *SamNode) DiscoverTokenURL(ctx context.Context, issuerURL string) (strin
 
 // DiscoverEndpoints discovers both token and authorization endpoints.
 func (n *SamNode) DiscoverEndpoints(ctx context.Context, issuerURL string) (tokenURL, authURL string, err error) {
-	provider, err := oidc.NewProvider(ctx, issuerURL)
+	client := &http.Client{Timeout: oidcDiscoveryTimeout}
+	provider, err := oidc.NewProvider(oidc.ClientContext(ctx, client), issuerURL)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create OIDC provider: %w", err)
 	}

--- a/internal/node/oidc_test.go
+++ b/internal/node/oidc_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -106,6 +107,46 @@ func TestDiscoverEndpoints(t *testing.T) {
 	}
 	if authURL != server.URL+"/auth" {
 		t.Errorf("Expected authURL %s, got %s", server.URL+"/auth", authURL)
+	}
+}
+
+// TestDiscoverEndpointsDoesNotHangOnUnresponsiveIssuer guards against an
+// unbounded hang: DiscoverEndpoints/DiscoverTokenURL used to call
+// oidc.NewProvider with no client timeout, so an issuer that accepts a
+// connection but never responds could block "join"/"run --join" forever.
+func TestDiscoverEndpointsDoesNotHangOnUnresponsiveIssuer(t *testing.T) {
+	origTimeout := oidcDiscoveryTimeout
+	oidcDiscoveryTimeout = 50 * time.Millisecond
+	defer func() { oidcDiscoveryTimeout = origTimeout }()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn // accepted but deliberately never responds, to simulate a hang
+		}
+	}()
+
+	node := &SamNode{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, _, err := node.DiscoverEndpoints(context.Background(), "http://"+ln.Addr().String()); err == nil {
+			t.Error("expected DiscoverEndpoints to fail against an unresponsive issuer")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("DiscoverEndpoints hung on an unresponsive issuer instead of timing out")
 	}
 }
 

--- a/internal/router/config.go
+++ b/internal/router/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/sam/api"
+	"github.com/google/sam/internal/identity"
 )
 
 // Options holds configuration details for the sam-router.
@@ -69,7 +70,7 @@ func (o *Options) Default() {
 		o.KeysDBPath = "router.key"
 	}
 	if o.BiscuitTimeout <= 0 {
-		o.BiscuitTimeout = 100 * time.Millisecond
+		o.BiscuitTimeout = identity.DefaultAuthorizerTimeout
 	}
 	if o.RequiredRole == "" {
 		o.RequiredRole = api.RoleRouter

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -326,7 +326,7 @@ func (r *Router) enroll(peerID peer.ID) error {
 	r.trustedPublicKeys = []ed25519.PublicKey{enrollResp.ControlPlanePublicKey}
 	r.keysMu.Unlock()
 
-	if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, enrollResp.ControlPlanePublicKey, r.config.RequiredRole); err != nil {
+	if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, enrollResp.ControlPlanePublicKey, r.config.RequiredRole, r.config.BiscuitTimeout); err != nil {
 		return fmt.Errorf("enrolled biscuit token lacks required role %q: %w", r.config.RequiredRole, err)
 	}
 
@@ -448,7 +448,7 @@ func (r *Router) enrollBootstrap(peerID peer.ID) error {
 	r.trustedPublicKeys = []ed25519.PublicKey{enrollResp.ControlPlanePublicKey}
 	r.keysMu.Unlock()
 
-	if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, enrollResp.ControlPlanePublicKey, r.config.RequiredRole); err != nil {
+	if err := identity.VerifyBiscuitRole(enrollResp.BiscuitToken, enrollResp.ControlPlanePublicKey, r.config.RequiredRole, r.config.BiscuitTimeout); err != nil {
 		return fmt.Errorf("enrolled biscuit token lacks required role %q: %w", r.config.RequiredRole, err)
 	}
 
@@ -939,7 +939,7 @@ func (r *Router) performMutualAuth(s network.Stream) error {
 	}
 
 	// Enforce required role inside the biscuit
-	authorizer, err := b.Authorizer(trustedKeys[0])
+	authorizer, err := b.Authorizer(trustedKeys[0], identity.AuthorizerOptions(r.config.BiscuitTimeout)...)
 	if err != nil {
 		return fmt.Errorf("authorizer instantiation failed: %w", err)
 	}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -794,3 +794,11 @@ func TestRouterConnectionManagerWatermarks(t *testing.T) {
 		t.Fatalf("expected default watermarks 1000/4000, got Low: %d, High: %d", defaultOpts.LowWaterMark, defaultOpts.HighWaterMark)
 	}
 }
+
+func TestRouterDefaultBiscuitTimeout(t *testing.T) {
+	opts := Options{}
+	opts.Default()
+	if opts.BiscuitTimeout != identity.DefaultAuthorizerTimeout {
+		t.Fatalf("expected default biscuit timeout %v, got %v", identity.DefaultAuthorizerTimeout, opts.BiscuitTimeout)
+	}
+}

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -198,7 +198,6 @@ func TestSamNodeJoinOfflineAccessSavesRefreshToken(t *testing.T) {
 	}
 }
 
-
 // TestSamNodeRunJoinNonInteractive covers the safe fallback: since the test
 // harness gives the child process no TTY (stdin defaults to /dev/null),
 // "run --join" must not attempt (and block on) an interactive OIDC login; it
@@ -405,4 +404,3 @@ func normalizeControlPlaneURLForTest(url string) string {
 	}
 	return strings.TrimSuffix(url, "/")
 }
-


### PR DESCRIPTION
…ogin

sam-console only discovered its OIDC provider once at startup. During a deployment rollout where sam-console, the control plane, and Dex are applied in quick succession, a transient discovery failure (Dex still starting) permanently set provider = nil for the pod's lifetime -- console's /info still reports 200 OK either way, so Kubernetes liveness/readiness probes pass and never restart it to retry, leaving the SSO login button hidden indefinitely (reproduced on bananas.sam-mesh.dev; hub.sam-mesh.dev happened to boot after Dex was already up).

Adds discoverProviderWithRetry, mirroring the existing helper of the same name in sam-control-plane (5 attempts, exponential backoff, ~15s worst case), and uses it for the console's OIDC discovery.

Adds a unit test reproducing the exact race (OIDC discovery failing twice before succeeding) confirming NewServer now recovers, plus a direct test of the retry helper's success/exhaustion paths.