### PR TITLE
ci: keep git clean after the mobile build so GoReleaser can release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,14 @@ jobs:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: make mobile-app-apk
+      - name: Restore files rewritten by the Flutter build
+        # `flutter build` re-resolves pubspec.lock (and may rewrite
+        # analysis_options.yaml), leaving the tree dirty and failing
+        # GoReleaser's git state validation. Build outputs are untracked, so
+        # restoring tracked files keeps the APK available for the upload step.
+        run: |
+          git -C mobile/sam-node-app checkout -- .
+          git status --porcelain
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:


### PR DESCRIPTION
The v0.1.0-alpha.6 release failed before publishing anything:

```
⨯ release failed: git is in a dirty state
M mobile/sam-node-app/analysis_options.yaml
M mobile/sam-node-app/pubspec.lock
```

`make mobile-app-apk` runs `flutter build apk --release`, which re-resolves the
checked-in `pubspec.lock` and rewrites `analysis_options.yaml`, so GoReleaser's
git state validation aborts the release.

Restore the tracked files under `mobile/sam-node-app` after the build. Build
outputs are untracked, so the APK is still there for the upload step, and the
mobile build keeps gating the release.