### PR TITLE
internal/node: fall back to DNS-over-TCP when a TXT lookup comes back…

### DIFF
--- a/internal/node/dnstcp.go
+++ b/internal/node/dnstcp.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	madns "github.com/multiformats/go-multiaddr-dns"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+// fqdnName appends a trailing dot, which dnsmessage.NewName requires for a
+// fully-qualified name, unless the caller already supplied one.
+func fqdnName(name string) string {
+	if strings.HasSuffix(name, ".") {
+		return name
+	}
+	return name + "."
+}
+
+// tcpFallbackResolver wraps a madns.BasicResolver and retries LookupTXT with
+// a direct DNS-over-TCP exchange whenever the wrapped (UDP-based) lookup
+// comes back empty. Some networks silently drop or corrupt UDP DNS responses
+// once they're large enough to need fragmentation, instead of returning the
+// truncated reply a resolver would normally retry over TCP on its own - which
+// breaks resolution of libp2p's dnsaddr TXT records (often several entries)
+// even though the record itself is fine and a plain TCP query resolves it.
+//
+// Observed concretely on a ChromeOS Crostini VM: its DNS proxy answered a
+// multi-entry dnsaddr TXT record with an empty result over plain UDP, and a
+// direct UDP query to 8.8.8.8/1.1.1.1 from the same VM came back partial and
+// flagged as a malformed packet - while `dig +tcp` and a second Linux machine
+// on the same network resolved it correctly every time. That points at the
+// VM's handling of a fragmented/oversized UDP response, not the record or
+// the wider network, so retrying over TCP - which needs no fragmentation -
+// is the fix rather than anything specific to that one environment.
+type tcpFallbackResolver struct {
+	def     madns.BasicResolver
+	servers []string // nameserver "host:port" entries used for the TCP retry
+}
+
+var _ madns.BasicResolver = (*tcpFallbackResolver)(nil)
+
+// newTCPFallbackResolver builds a tcpFallbackResolver backed by def, using
+// the system's configured nameservers (from /etc/resolv.conf) for the TCP
+// retry. If none can be determined (e.g. on Windows), the TCP retry is
+// simply never attempted and def's own result/error is always returned.
+func newTCPFallbackResolver(def madns.BasicResolver) *tcpFallbackResolver {
+	servers, err := systemNameservers()
+	if err != nil {
+		logger.Debugf("dnstcp: no nameservers for TCP fallback: %v", err)
+	}
+	return &tcpFallbackResolver{def: def, servers: servers}
+}
+
+func (r *tcpFallbackResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return r.def.LookupIPAddr(ctx, host)
+}
+
+func (r *tcpFallbackResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
+	txt, err := r.def.LookupTXT(ctx, name)
+	if err == nil && len(txt) > 0 {
+		return txt, nil
+	}
+	if len(r.servers) == 0 {
+		return txt, err
+	}
+	tcpTXT, tcpErr := lookupTXTOverTCP(ctx, name, r.servers)
+	if tcpErr != nil || len(tcpTXT) == 0 {
+		logger.Debugf("dnstcp: TCP fallback for TXT %q also failed: %v", name, tcpErr)
+		return txt, err
+	}
+	logger.Debugf("dnstcp: recovered %d TXT record(s) for %q via TCP after an empty UDP result", len(tcpTXT), name)
+	return tcpTXT, nil
+}
+
+// lookupTXTOverTCP resolves a TXT record with a direct, length-prefixed
+// DNS-over-TCP exchange (RFC 1035 section 4.2.2) against servers in order,
+// bypassing the standard resolver's UDP-first behavior entirely.
+func lookupTXTOverTCP(ctx context.Context, name string, servers []string) ([]string, error) {
+	qname, err := dnsmessage.NewName(fqdnName(name))
+	if err != nil {
+		return nil, fmt.Errorf("invalid DNS name %q: %w", name, err)
+	}
+	query := dnsmessage.Message{
+		Header: dnsmessage.Header{ID: uint16(time.Now().UnixNano()), RecursionDesired: true},
+		Questions: []dnsmessage.Question{{
+			Name:  qname,
+			Type:  dnsmessage.TypeTXT,
+			Class: dnsmessage.ClassINET,
+		}},
+	}
+	packed, err := query.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build DNS query: %w", err)
+	}
+
+	var lastErr error
+	for _, server := range servers {
+		txt, err := exchangeTCP(ctx, server, packed)
+		if err == nil {
+			return txt, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func exchangeTCP(ctx context.Context, server string, query []byte) ([]string, error) {
+	d := net.Dialer{Timeout: 5 * time.Second}
+	conn, err := d.DialContext(ctx, "tcp", server)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", server, err)
+	}
+	defer func() { _ = conn.Close() }()
+	deadline := time.Now().Add(5 * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	_ = conn.SetDeadline(deadline)
+
+	var lenBuf [2]byte
+	binary.BigEndian.PutUint16(lenBuf[:], uint16(len(query)))
+	if _, err := conn.Write(lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("writing length prefix to %s: %w", server, err)
+	}
+	if _, err := conn.Write(query); err != nil {
+		return nil, fmt.Errorf("writing query to %s: %w", server, err)
+	}
+
+	if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("reading response length from %s: %w", server, err)
+	}
+	resp := make([]byte, binary.BigEndian.Uint16(lenBuf[:]))
+	if _, err := io.ReadFull(conn, resp); err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", server, err)
+	}
+
+	var msg dnsmessage.Message
+	if err := msg.Unpack(resp); err != nil {
+		return nil, fmt.Errorf("parsing DNS response from %s: %w", server, err)
+	}
+	if msg.RCode != dnsmessage.RCodeSuccess {
+		return nil, fmt.Errorf("%s returned %s", server, msg.RCode)
+	}
+
+	var out []string
+	for _, ans := range msg.Answers {
+		if txtRes, ok := ans.Body.(*dnsmessage.TXTResource); ok {
+			out = append(out, strings.Join(txtRes.TXT, ""))
+		}
+	}
+	return out, nil
+}
+
+// systemNameservers reads the "nameserver" entries from /etc/resolv.conf.
+// It returns a nil slice, not an error, when the file doesn't exist (e.g. on
+// Windows) so callers can silently skip the TCP fallback there.
+func systemNameservers() ([]string, error) {
+	data, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return parseNameservers(string(data)), nil
+}
+
+// parseNameservers extracts "host:port" nameserver entries (port 53) from
+// the contents of a resolv.conf file.
+func parseNameservers(resolvConf string) []string {
+	var servers []string
+	for _, line := range strings.Split(resolvConf, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "nameserver" {
+			continue
+		}
+		servers = append(servers, net.JoinHostPort(fields[1], "53"))
+	}
+	return servers
+}
+
+func init() {
+	r, err := madns.NewResolver(madns.WithDefaultResolver(newTCPFallbackResolver(net.DefaultResolver)))
+	if err != nil {
+		logger.Warnf("dnstcp: failed to install TCP-fallback DNS resolver, dnsaddr resolution keeps its default UDP-only behavior: %v", err)
+		return
+	}
+	madns.DefaultResolver = r
+}

--- a/internal/node/dnstcp.go
+++ b/internal/node/dnstcp.go
@@ -54,22 +54,22 @@ func fqdnName(name string) string {
 // the wider network, so retrying over TCP - which needs no fragmentation -
 // is the fix rather than anything specific to that one environment.
 type tcpFallbackResolver struct {
-	def     madns.BasicResolver
-	servers []string // nameserver "host:port" entries used for the TCP retry
+	def madns.BasicResolver
+	// servers overrides the nameservers used for the TCP retry; only set in
+	// tests. Production leaves this nil and reads /etc/resolv.conf fresh on
+	// every fallback instead, so nameserver changes take effect immediately.
+	servers []string
 }
 
 var _ madns.BasicResolver = (*tcpFallbackResolver)(nil)
 
-// newTCPFallbackResolver builds a tcpFallbackResolver backed by def, using
-// the system's configured nameservers (from /etc/resolv.conf) for the TCP
-// retry. If none can be determined (e.g. on Windows), the TCP retry is
-// simply never attempted and def's own result/error is always returned.
+// newTCPFallbackResolver builds a tcpFallbackResolver backed by def. The
+// system's configured nameservers are read from /etc/resolv.conf on demand
+// for each TCP retry (see LookupTXT) rather than cached here, so the node
+// keeps working across VPN connects, Wi-Fi switches, and DHCP renewals
+// without needing a restart.
 func newTCPFallbackResolver(def madns.BasicResolver) *tcpFallbackResolver {
-	servers, err := systemNameservers()
-	if err != nil {
-		logger.Debugf("dnstcp: no nameservers for TCP fallback: %v", err)
-	}
-	return &tcpFallbackResolver{def: def, servers: servers}
+	return &tcpFallbackResolver{def: def}
 }
 
 func (r *tcpFallbackResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
@@ -81,10 +81,20 @@ func (r *tcpFallbackResolver) LookupTXT(ctx context.Context, name string) ([]str
 	if err == nil && len(txt) > 0 {
 		return txt, nil
 	}
-	if len(r.servers) == 0 {
+	// r.servers is a test-only override; production always re-reads
+	// /etc/resolv.conf here so nameserver changes take effect immediately.
+	servers := r.servers
+	if len(servers) == 0 {
+		var sysErr error
+		servers, sysErr = systemNameservers()
+		if sysErr != nil {
+			logger.Debugf("dnstcp: no nameservers for TCP fallback: %v", sysErr)
+		}
+	}
+	if len(servers) == 0 {
 		return txt, err
 	}
-	tcpTXT, tcpErr := lookupTXTOverTCP(ctx, name, r.servers)
+	tcpTXT, tcpErr := lookupTXTOverTCP(ctx, name, servers)
 	if tcpErr != nil || len(tcpTXT) == 0 {
 		logger.Debugf("dnstcp: TCP fallback for TXT %q also failed: %v", name, tcpErr)
 		return txt, err
@@ -138,6 +148,20 @@ func exchangeTCP(ctx context.Context, server string, query []byte) ([]string, er
 	}
 	_ = conn.SetDeadline(deadline)
 
+	// conn.Write/Read below only respect the deadline above, not ctx
+	// cancellation directly; close the connection as soon as the caller's
+	// context is done so a cancelled/timed-out caller isn't stuck waiting
+	// out the full deadline.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
 	var lenBuf [2]byte
 	binary.BigEndian.PutUint16(lenBuf[:], uint16(len(query)))
 	if _, err := conn.Write(lenBuf[:]); err != nil {
@@ -172,11 +196,15 @@ func exchangeTCP(ctx context.Context, server string, query []byte) ([]string, er
 	return out, nil
 }
 
+// resolvConfPath is a package-level var (rather than a hardcoded literal)
+// purely so tests can point it at a fixture without touching the real file.
+var resolvConfPath = "/etc/resolv.conf"
+
 // systemNameservers reads the "nameserver" entries from /etc/resolv.conf.
 // It returns a nil slice, not an error, when the file doesn't exist (e.g. on
 // Windows) so callers can silently skip the TCP fallback there.
 func systemNameservers() ([]string, error) {
-	data, err := os.ReadFile("/etc/resolv.conf")
+	data, err := os.ReadFile(resolvConfPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/internal/node/dnstcp_test.go
+++ b/internal/node/dnstcp_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func TestParseNameservers(t *testing.T) {
+	const resolvConf = `# comment, ignored
+nameserver 127.0.0.53
+options edns0 trust-ad
+nameserver 2001:db8::1
+search example.com
+`
+	got := parseNameservers(resolvConf)
+	want := []string{"127.0.0.53:53", "[2001:db8::1]:53"}
+	if len(got) != len(want) {
+		t.Fatalf("parseNameservers() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("parseNameservers()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// startFakeDNSOverTCP starts a minimal length-prefixed DNS-over-TCP server
+// that always answers with the given TXT strings, and returns its address.
+func startFakeDNSOverTCP(t *testing.T, txt []string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start fake DNS server: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		var lenBuf [2]byte
+		if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
+			return
+		}
+		query := make([]byte, binary.BigEndian.Uint16(lenBuf[:]))
+		if _, err := io.ReadFull(conn, query); err != nil {
+			return
+		}
+		var q dnsmessage.Message
+		if err := q.Unpack(query); err != nil {
+			return
+		}
+
+		resp := dnsmessage.Message{
+			Header:    dnsmessage.Header{ID: q.ID, Response: true, RCode: dnsmessage.RCodeSuccess},
+			Questions: q.Questions,
+		}
+		for _, s := range txt {
+			resp.Answers = append(resp.Answers, dnsmessage.Resource{
+				Header: dnsmessage.ResourceHeader{
+					Name:  q.Questions[0].Name,
+					Type:  dnsmessage.TypeTXT,
+					Class: dnsmessage.ClassINET,
+					TTL:   300,
+				},
+				Body: &dnsmessage.TXTResource{TXT: []string{s}},
+			})
+		}
+		packed, err := resp.Pack()
+		if err != nil {
+			return
+		}
+		var out [2]byte
+		binary.BigEndian.PutUint16(out[:], uint16(len(packed)))
+		_, _ = conn.Write(out[:])
+		_, _ = conn.Write(packed)
+	}()
+
+	return ln.Addr().String()
+}
+
+func TestLookupTXTOverTCP(t *testing.T) {
+	want := []string{"dnsaddr=/ip4/1.2.3.4/tcp/4501/p2p/foo", "dnsaddr=/ip4/1.2.3.4/udp/4501/quic-v1/p2p/foo"}
+	server := startFakeDNSOverTCP(t, want)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := lookupTXTOverTCP(ctx, "_dnsaddr.example.com", []string{server})
+	if err != nil {
+		t.Fatalf("lookupTXTOverTCP failed: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("lookupTXTOverTCP() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("lookupTXTOverTCP()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// stubResolver is a minimal madns.BasicResolver test double.
+type stubResolver struct {
+	txt    []string
+	txtErr error
+}
+
+func (s *stubResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *stubResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
+	return s.txt, s.txtErr
+}
+
+func TestTCPFallbackResolver_FallsBackWhenUDPEmpty(t *testing.T) {
+	want := []string{"dnsaddr=/ip4/5.6.7.8/tcp/4501/p2p/bar"}
+	server := startFakeDNSOverTCP(t, want)
+
+	r := &tcpFallbackResolver{def: &stubResolver{}, servers: []string{server}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := r.LookupTXT(ctx, "_dnsaddr.example.com")
+	if err != nil {
+		t.Fatalf("LookupTXT failed: %v", err)
+	}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("LookupTXT() = %v, want %v", got, want)
+	}
+}
+
+func TestTCPFallbackResolver_UsesUDPResultWhenNonEmpty(t *testing.T) {
+	want := []string{"dnsaddr=/ip4/9.9.9.9/tcp/4501/p2p/baz"}
+	// An unroutable TEST-NET-3 address (RFC 5737): if the wrapper incorrectly
+	// attempted the TCP fallback despite a good UDP result, this would hang
+	// until the context deadline instead of returning immediately.
+	r := &tcpFallbackResolver{def: &stubResolver{txt: want}, servers: []string{"203.0.113.1:53"}}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	got, err := r.LookupTXT(ctx, "_dnsaddr.example.com")
+	if err != nil {
+		t.Fatalf("LookupTXT failed: %v", err)
+	}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("LookupTXT() = %v, want %v", got, want)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("LookupTXT() took %s; a good UDP result must short-circuit the TCP fallback", elapsed)
+	}
+}
+
+func TestTCPFallbackResolver_NoServersReturnsOriginalResult(t *testing.T) {
+	origErr := errors.New("boom")
+	r := &tcpFallbackResolver{def: &stubResolver{txtErr: origErr}}
+
+	_, err := r.LookupTXT(context.Background(), "_dnsaddr.example.com")
+	if !errors.Is(err, origErr) {
+		t.Errorf("LookupTXT() error = %v, want %v", err, origErr)
+	}
+}

--- a/internal/node/dnstcp_test.go
+++ b/internal/node/dnstcp_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -42,6 +43,38 @@ search example.com
 		if got[i] != want[i] {
 			t.Errorf("parseNameservers()[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestSystemNameservers_NotCachedAcrossCalls(t *testing.T) {
+	oldPath := resolvConfPath
+	path := t.TempDir() + "/resolv.conf"
+	resolvConfPath = path
+	t.Cleanup(func() { resolvConfPath = oldPath })
+
+	if err := os.WriteFile(path, []byte("nameserver 10.0.0.1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := systemNameservers()
+	if err != nil {
+		t.Fatalf("systemNameservers() error = %v", err)
+	}
+	if want := []string{"10.0.0.1:53"}; len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("systemNameservers() = %v, want %v", got, want)
+	}
+
+	// A network change (VPN, Wi-Fi switch, DHCP renewal) rewrites
+	// resolv.conf; the next call must reflect it immediately, not a value
+	// cached from construction time.
+	if err := os.WriteFile(path, []byte("nameserver 10.0.0.2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err = systemNameservers()
+	if err != nil {
+		t.Fatalf("systemNameservers() error = %v", err)
+	}
+	if want := []string{"10.0.0.2:53"}; len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("systemNameservers() after resolv.conf changed = %v, want %v", got, want)
 	}
 }
 
@@ -177,6 +210,13 @@ func TestTCPFallbackResolver_UsesUDPResultWhenNonEmpty(t *testing.T) {
 }
 
 func TestTCPFallbackResolver_NoServersReturnsOriginalResult(t *testing.T) {
+	// Point at a nonexistent resolv.conf so systemNameservers() finds no
+	// servers deterministically, instead of the LookupTXT change (reading
+	// /etc/resolv.conf on demand) hitting this machine's real DNS config.
+	oldPath := resolvConfPath
+	resolvConfPath = t.TempDir() + "/does-not-exist"
+	t.Cleanup(func() { resolvConfPath = oldPath })
+
 	origErr := errors.New("boom")
 	r := &tcpFallbackResolver{def: &stubResolver{txtErr: origErr}}
 


### PR DESCRIPTION
… empty

libp2p's dnsaddr resolution ('no good addresses') was failing on a ChromeOS Crostini VM even though the _dnsaddr TXT record was valid: 'dig' with the default (UDP) resolver returned nothing, 'dig +tcp' returned it cleanly, and querying 8.8.8.8/1.1.1.1 directly over UDP came back partial and flagged as a malformed packet - while 'dig +trace' full traversal, and a second Linux machine on the same network, resolved it correctly every time. That points at this VM's handling of a fragmented/oversized UDP response, not the record or the network path, since a plain TCP query sidesteps the problem entirely.

Add tcpFallbackResolver (internal/node/dnstcp.go), wrapping madns.BasicResolver: if the wrapped LookupTXT returns empty, retry with a direct, length-prefixed DNS-over-TCP exchange (via golang.org/x/net/dns/dnsmessage, already a dependency - no go.mod change) against the system's configured nameservers, before giving up. Wired in via an init() that replaces madns.DefaultResolver, so both sam-node and sam-box get it automatically with no flag or env var needed.

Verified live against the real bananas.sam-mesh.dev testnet on the affected machine: 'sam-node run --join' went from a hard failure ('no good addresses' on 3 of 5 candidate routers) to 'SAM Node Online'. Added unit tests: a fake DNS-over-TCP server for the wire-format exchange, and coverage for both fallback branches (short-circuits under 1s when the UDP result is already non-empty; falls back and recovers when it's empty).