### PR TITLE
node: add OAuth device flow for headless enrollment with browser-fail…

### DIFF
--- a/agents/skills/sam-mesh/SKILL.md
+++ b/agents/skills/sam-mesh/SKILL.md
@@ -39,8 +39,10 @@ approve it before running anything.
    so no pasted callback code is required: it prints a verification URL/code
    and polls until login completes. If the provider does not expose a device
    endpoint, SAM falls back to OOB code-paste flow; show the URL/code to the
-   user, wait for completion, then repeat step 2. Enrollment is a one-time step
-   per machine.
+   user, wait for completion, then repeat step 2. For deterministic automation,
+   force the flow with `--auth-mode device` (also `oob`, `browser`, or the
+   default `auto`); `--auth-mode device` fails fast if the provider has no
+   device endpoint. Enrollment is a one-time step per machine.
 4. Read the node API token from the file named in step 2, then register the MCP
    endpoint `http://127.0.0.1:8080/mcp` with the header
    `X-Sam-Authentication: Bearer <token>`. Claude Code:

--- a/agents/skills/sam-mesh/SKILL.md
+++ b/agents/skills/sam-mesh/SKILL.md
@@ -34,9 +34,13 @@ approve it before running anything.
    log file, and how to stop it. It is idempotent, so run it again whenever you
    need to confirm a node is up.
 3. If step 2 reports that the node is not enrolled, run the command it prints,
-   `sam-node join --headless <control-plane-url>`. That prints a URL and a
-   code: show both to the user and wait while they complete the login, then
-   repeat step 2. Enrollment is a one-time step per machine.
+   `sam-node join --headless <control-plane-url>`. In headless mode SAM now
+   prefers OAuth device flow automatically when the OIDC provider supports it,
+   so no pasted callback code is required: it prints a verification URL/code
+   and polls until login completes. If the provider does not expose a device
+   endpoint, SAM falls back to OOB code-paste flow; show the URL/code to the
+   user, wait for completion, then repeat step 2. Enrollment is a one-time step
+   per machine.
 4. Read the node API token from the file named in step 2, then register the MCP
    endpoint `http://127.0.0.1:8080/mcp` with the header
    `X-Sam-Authentication: Bearer <token>`. Claude Code:

--- a/cmd/sam-box/main.go
+++ b/cmd/sam-box/main.go
@@ -424,12 +424,16 @@ func main() {
 				fmt.Printf("Client ID discovered: %s\n", controlPlaneInfo.ClientId)
 
 				logger.Info("Discovering OIDC endpoints...")
-				tokenURL, authURL, err := dummyNode.DiscoverEndpoints(ctx, controlPlaneInfo.OidcIssuer)
+				endpoints, err := dummyNode.DiscoverEndpointsWithDevice(ctx, controlPlaneInfo.OidcIssuer)
 				if err != nil {
 					logger.Fatalf("Failed to discover OIDC endpoints: %v", err)
 				}
+				deviceAuthURL := endpoints.DeviceAuthURL
+				if deviceAuthURLFlag != "" {
+					deviceAuthURL = deviceAuthURLFlag
+				}
 
-				jwtStr, err = dummyNode.InteractiveLogin(ctx, authURL, tokenURL, controlPlaneInfo.ClientId, controlPlaneInfo.Audience, offlineAccessFlag, headlessFlag)
+				jwtStr, err = dummyNode.InteractiveLoginWithDeviceAuth(ctx, endpoints.AuthURL, endpoints.TokenURL, deviceAuthURL, controlPlaneInfo.ClientId, controlPlaneInfo.Audience, offlineAccessFlag, headlessFlag)
 				if err != nil {
 					logger.Fatalf("Failed to get token: %v", err)
 				}

--- a/cmd/sam-box/main.go
+++ b/cmd/sam-box/main.go
@@ -71,6 +71,7 @@ var (
 	audienceFlag              string
 	dataDirFlag               string
 	headlessFlag              bool
+	authModeFlag              string
 	offlineAccessFlag         bool
 	logLevelFlag              string
 	keyGracePeriodFlag        time.Duration
@@ -433,7 +434,12 @@ func main() {
 					deviceAuthURL = deviceAuthURLFlag
 				}
 
-				jwtStr, err = dummyNode.InteractiveLoginWithDeviceAuth(ctx, endpoints.AuthURL, endpoints.TokenURL, deviceAuthURL, controlPlaneInfo.ClientId, controlPlaneInfo.Audience, offlineAccessFlag, headlessFlag)
+				mode, err := node.ParseAuthMode(authModeFlag)
+				if err != nil {
+					logger.Fatalf("Invalid --auth-mode: %v", err)
+				}
+
+				jwtStr, err = dummyNode.InteractiveLoginWithMode(ctx, endpoints.AuthURL, endpoints.TokenURL, deviceAuthURL, controlPlaneInfo.ClientId, controlPlaneInfo.Audience, offlineAccessFlag, headlessFlag, mode)
 				if err != nil {
 					logger.Fatalf("Failed to get token: %v", err)
 				}
@@ -554,6 +560,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&audienceFlag, "audience", api.DefaultAudience, "OIDC Audience")
 	rootCmd.PersistentFlags().StringVar(&dataDirFlag, "data-dir", "", "Override directory for the agent store (defaults to OS user config dir)")
 	rootCmd.PersistentFlags().BoolVar(&headlessFlag, "headless", false, "Force headless out-of-band (OOB) authentication flow")
+	rootCmd.PersistentFlags().StringVar(&authModeFlag, "auth-mode", "auto", "Interactive enrollment auth mode: auto, device, oob, or browser")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(joinCmd)

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -73,6 +73,7 @@ var (
 	audienceFlag              string
 	dataDirFlag               string
 	headlessFlag              bool
+	authModeFlag              string
 	daemonizeFlag             bool
 	resetAllFlag              bool
 	assumeYesFlag             bool
@@ -285,7 +286,12 @@ func interactiveJoin(ctx context.Context, store *node.Store, targetControlPlane 
 		deviceAuthURL = deviceAuthURLFlag
 	}
 
-	jwtStr, err := dummyNode.InteractiveLoginWithDeviceAuth(ctx, endpoints.AuthURL, endpoints.TokenURL, deviceAuthURL, info.ClientId, info.Audience, offlineAccessFlag, headlessFlag)
+	mode, err := node.ParseAuthMode(authModeFlag)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid --auth-mode: %w", err)
+	}
+
+	jwtStr, err := dummyNode.InteractiveLoginWithMode(ctx, endpoints.AuthURL, endpoints.TokenURL, deviceAuthURL, info.ClientId, info.Audience, offlineAccessFlag, headlessFlag, mode)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get token: %w", err)
 	}
@@ -939,6 +945,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&audienceFlag, "audience", api.DefaultAudience, "OIDC Audience")
 	rootCmd.PersistentFlags().StringVar(&dataDirFlag, "data-dir", "", "Override directory for the agent store (defaults to OS user config dir)")
 	rootCmd.PersistentFlags().BoolVar(&headlessFlag, "headless", false, "Force headless out-of-band (OOB) authentication flow")
+	rootCmd.PersistentFlags().StringVar(&authModeFlag, "auth-mode", "auto", "Interactive enrollment auth mode: auto, device, oob, or browser")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(joinCmd)

--- a/cmd/sam-node/main.go
+++ b/cmd/sam-node/main.go
@@ -276,12 +276,16 @@ func interactiveJoin(ctx context.Context, store *node.Store, targetControlPlane 
 	fmt.Printf("Client ID discovered: %s\n", info.ClientId)
 
 	logger.Info("Discovering OIDC endpoints...")
-	tokenURL, authURL, err := dummyNode.DiscoverEndpoints(ctx, info.OidcIssuer)
+	endpoints, err := dummyNode.DiscoverEndpointsWithDevice(ctx, info.OidcIssuer)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to discover OIDC endpoints: %w", err)
 	}
+	deviceAuthURL := endpoints.DeviceAuthURL
+	if deviceAuthURLFlag != "" {
+		deviceAuthURL = deviceAuthURLFlag
+	}
 
-	jwtStr, err := dummyNode.InteractiveLogin(ctx, authURL, tokenURL, info.ClientId, info.Audience, offlineAccessFlag, headlessFlag)
+	jwtStr, err := dummyNode.InteractiveLoginWithDeviceAuth(ctx, endpoints.AuthURL, endpoints.TokenURL, deviceAuthURL, info.ClientId, info.Audience, offlineAccessFlag, headlessFlag)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get token: %w", err)
 	}

--- a/internal/node/oidc.go
+++ b/internal/node/oidc.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -62,6 +63,13 @@ func (n *SamNode) FetchJWT(ctx context.Context, tokenURL, clientID, clientSecret
 
 // InteractiveLogin prompts the user to go to a URL and enter a code.
 func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clientID, audience string, requestRefresh bool, headless bool) (string, error) {
+	return n.InteractiveLoginWithDeviceAuth(ctx, authURL, tokenURL, "", clientID, audience, requestRefresh, headless)
+}
+
+// InteractiveLoginWithDeviceAuth prompts the user to authenticate, preferring
+// OAuth Device Authorization Grant in headless mode when the provider exposes
+// a device authorization endpoint.
+func (n *SamNode) InteractiveLoginWithDeviceAuth(ctx context.Context, authURL, tokenURL, deviceAuthURL, clientID, audience string, requestRefresh bool, headless bool) (string, error) {
 	if authURL == "" {
 		return "", fmt.Errorf("authorization URL is required")
 	}
@@ -85,10 +93,18 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 
 	isHeadless := headless || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != ""
 
+	if isHeadless && deviceAuthURL != "" {
+		logger.Info("Headless mode detected and device authorization endpoint available; using device flow")
+		return n.DeviceLogin(ctx, deviceAuthURL, tokenURL, clientID, audience, requestRefresh)
+	}
+
 	var redirectURI string
 	var listener net.Listener
 
 	if isHeadless {
+		if !stdinIsInteractive() {
+			logger.Warn("Headless OOB flow requires pasting a code, but stdin is non-interactive and no device endpoint is configured; auth may block")
+		}
 		redirectURI = "urn:ietf:wg:oauth:2.0:oob"
 	} else {
 		var err error
@@ -102,6 +118,10 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 			}
 		}
 		if listener == nil {
+			if deviceAuthURL != "" {
+				logger.Warn("Could not bind local OIDC listener (ports 13000-13002 busy); falling back to device authorization flow.")
+				return n.DeviceLogin(ctx, deviceAuthURL, tokenURL, clientID, audience, requestRefresh)
+			}
 			logger.Warn("Could not bind local OIDC listener (ports 13000-13002 busy). Falling back to headless (OOB) authorization.")
 			isHeadless = true
 			redirectURI = "urn:ietf:wg:oauth:2.0:oob"
@@ -136,6 +156,22 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 	authReq.URL.RawQuery = q.Encode()
 	targetURL := authReq.URL.String()
 
+	// In an interactive (loopback) flow, try to open the browser up front. If it
+	// can't be opened, nothing will complete the redirect, so when the provider
+	// advertises a device authorization endpoint we fall back to device flow
+	// rather than forcing the user (or a CUJ harness) to paste a callback code
+	// back. Headless flows open the browser only best-effort (after the banner),
+	// since they already print a URL to complete elsewhere.
+	if !isHeadless {
+		if err := openBrowserFunc(targetURL); err != nil {
+			if deviceAuthURL != "" {
+				logger.Warnf("Could not open a browser (%v); falling back to device authorization flow.", err)
+				return n.DeviceLogin(ctx, deviceAuthURL, tokenURL, clientID, audience, requestRefresh)
+			}
+			logger.Warnf("Could not open a browser (%v); open the URL below manually or paste the callback code.", err)
+		}
+	}
+
 	fmt.Println("------------------------------------------------------------")
 	fmt.Println("OAuth Authorization Flow")
 	fmt.Println("------------------------------------------------------------")
@@ -148,8 +184,10 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 	}
 	fmt.Println("------------------------------------------------------------")
 
-	// Try to open browser automatically
-	openBrowserFunc(targetURL)
+	if isHeadless {
+		// Best-effort: some headless setups still have a usable browser.
+		_ = openBrowserFunc(targetURL)
+	}
 
 	loginCtx, loginCancel := context.WithCancel(ctx)
 	defer loginCancel()
@@ -266,6 +304,61 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 	if err != nil {
 		return "", err
 	}
+
+	jwt, refreshToken, err := parseTokenResponse(resp)
+	if err != nil {
+		return "", err
+	}
+	if refreshToken != "" && n.Store != nil {
+		if err := n.Store.SaveRefreshToken(refreshToken); err != nil {
+			logger.Warnf("Failed to save refresh token: %v", err)
+		}
+	}
+	return jwt, nil
+}
+
+func stdinIsInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// DeviceLogin performs OAuth 2.0 Device Authorization Grant (RFC 8628).
+func (n *SamNode) DeviceLogin(ctx context.Context, deviceAuthURL, tokenURL, clientID, audience string, requestRefresh bool) (string, error) {
+	if deviceAuthURL == "" {
+		return "", fmt.Errorf("device authorization URL is required")
+	}
+	if tokenURL == "" {
+		return "", fmt.Errorf("token URL is required")
+	}
+	if clientID == "" {
+		return "", fmt.Errorf("client ID is required")
+	}
+
+	deviceData := url.Values{}
+	deviceData.Set("client_id", clientID)
+	scope := "openid email profile"
+	if requestRefresh {
+		scope += " offline_access"
+	}
+	deviceData.Set("scope", scope)
+	if audience != "" {
+		deviceData.Set("audience", audience)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", deviceAuthURL, strings.NewReader(deviceData.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create device authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("device authorization request failed: %w", err)
+	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			logger.Errorf("Failed to close response body: %v", err)
@@ -278,7 +371,169 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 			ErrorDescription string `json:"error_description"`
 		}
 		_ = json.NewDecoder(resp.Body).Decode(&errResp)
-		return "", fmt.Errorf("token request failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+		return "", fmt.Errorf("device authorization failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+	}
+
+	var deviceResp struct {
+		DeviceCode              string `json:"device_code"`
+		UserCode                string `json:"user_code"`
+		VerificationURI         string `json:"verification_uri"`
+		VerificationURIComplete string `json:"verification_uri_complete"`
+		ExpiresIn               int    `json:"expires_in"`
+		Interval                int    `json:"interval"`
+		Message                 string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
+		return "", fmt.Errorf("failed to decode device authorization response: %w", err)
+	}
+	if deviceResp.DeviceCode == "" {
+		return "", fmt.Errorf("device authorization response missing device_code")
+	}
+
+	verificationURL := deviceResp.VerificationURI
+	if deviceResp.VerificationURIComplete != "" {
+		verificationURL = deviceResp.VerificationURIComplete
+	}
+
+	fmt.Println("------------------------------------------------------------")
+	fmt.Println("OAuth Device Authorization Flow")
+	fmt.Println("------------------------------------------------------------")
+	if deviceResp.Message != "" {
+		fmt.Println(deviceResp.Message)
+		fmt.Println()
+	} else {
+		if verificationURL != "" {
+			fmt.Printf("Open this URL in a browser:\n\n  %s\n\n", verificationURL)
+		}
+		if deviceResp.UserCode != "" {
+			fmt.Printf("Enter code: %s\n\n", deviceResp.UserCode)
+		}
+	}
+	fmt.Println("Waiting for authorization...")
+	fmt.Println("------------------------------------------------------------")
+
+	pollInterval := 5 * time.Second
+	if deviceResp.Interval > 0 {
+		pollInterval = time.Duration(deviceResp.Interval) * time.Second
+	}
+	var expiresAt time.Time
+	if deviceResp.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+
+		if !expiresAt.IsZero() && time.Now().After(expiresAt) {
+			return "", fmt.Errorf("device authorization expired before completion")
+		}
+
+		tokenData := url.Values{}
+		tokenData.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+		tokenData.Set("device_code", deviceResp.DeviceCode)
+		tokenData.Set("client_id", clientID)
+
+		tokenReq, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(tokenData.Encode()))
+		if err != nil {
+			return "", fmt.Errorf("failed to create token polling request: %w", err)
+		}
+		tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		tokenResp, err := client.Do(tokenReq)
+		if err != nil {
+			return "", fmt.Errorf("token polling request failed: %w", err)
+		}
+
+		body, readErr := io.ReadAll(tokenResp.Body)
+		if closeErr := tokenResp.Body.Close(); closeErr != nil {
+			logger.Errorf("Failed to close response body: %v", closeErr)
+		}
+		if readErr != nil {
+			return "", fmt.Errorf("failed to read token polling response: %w", readErr)
+		}
+
+		if tokenResp.StatusCode == http.StatusOK {
+			var tokenData struct {
+				AccessToken  string `json:"access_token"`
+				IdToken      string `json:"id_token"`
+				RefreshToken string `json:"refresh_token"`
+			}
+			if err := json.Unmarshal(body, &tokenData); err != nil {
+				return "", fmt.Errorf("failed to decode token response: %w", err)
+			}
+			jwt := tokenData.AccessToken
+			if tokenData.IdToken != "" {
+				jwt = tokenData.IdToken
+			}
+			if jwt == "" {
+				return "", fmt.Errorf("token response did not contain an access_token or id_token")
+			}
+			if tokenData.RefreshToken != "" && n.Store != nil {
+				if saveErr := n.Store.SaveRefreshToken(tokenData.RefreshToken); saveErr != nil {
+					logger.Warnf("Failed to save refresh token: %v", saveErr)
+				}
+			}
+			return jwt, nil
+		}
+
+		if tokenResp.StatusCode != http.StatusBadRequest {
+			return "", fmt.Errorf("token request failed with status: %s", tokenResp.Status)
+		}
+
+		var errResp struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			return "", fmt.Errorf("failed to decode token polling error response: %w", err)
+		}
+
+		switch errResp.Error {
+		case "authorization_pending":
+			// keep polling
+		case "slow_down":
+			pollInterval += 5 * time.Second
+		case "access_denied":
+			return "", fmt.Errorf("device authorization denied by user")
+		case "expired_token":
+			return "", fmt.Errorf("device authorization expired")
+		default:
+			return "", fmt.Errorf("device token polling failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func parseTokenResponse(resp *http.Response) (jwt string, refreshToken string, err error) {
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.Errorf("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return "", "", readErr
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		if unmarshalErr := json.Unmarshal(body, &errResp); unmarshalErr == nil && errResp.Error != "" {
+			return "", "", fmt.Errorf("token request failed: %s - %s", errResp.Error, errResp.ErrorDescription)
+		}
+		return "", "", fmt.Errorf("token request failed with status: %s", resp.Status)
 	}
 
 	var tokenResp struct {
@@ -286,20 +541,18 @@ func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clien
 		IdToken      string `json:"id_token"`
 		RefreshToken string `json:"refresh_token"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-		return "", err
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", "", err
 	}
 
-	if tokenResp.RefreshToken != "" && n.Store != nil {
-		if err := n.Store.SaveRefreshToken(tokenResp.RefreshToken); err != nil {
-			logger.Warnf("Failed to save refresh token: %v", err)
-		}
-	}
-
+	jwt = tokenResp.AccessToken
 	if tokenResp.IdToken != "" {
-		return tokenResp.IdToken, nil
+		jwt = tokenResp.IdToken
 	}
-	return tokenResp.AccessToken, nil
+	if jwt == "" {
+		return "", "", fmt.Errorf("token response did not contain an access_token or id_token")
+	}
+	return jwt, tokenResp.RefreshToken, nil
 }
 
 // oidcDiscoveryTimeout bounds a single OIDC discovery HTTP call so an
@@ -328,28 +581,48 @@ func (n *SamNode) DiscoverTokenURL(ctx context.Context, issuerURL string) (strin
 
 // DiscoverEndpoints discovers both token and authorization endpoints.
 func (n *SamNode) DiscoverEndpoints(ctx context.Context, issuerURL string) (tokenURL, authURL string, err error) {
+	endpoints, err := n.DiscoverEndpointsWithDevice(ctx, issuerURL)
+	if err != nil {
+		return "", "", err
+	}
+	return endpoints.TokenURL, endpoints.AuthURL, nil
+}
+
+// OIDCEndpoints contains discovered OIDC endpoint URLs.
+type OIDCEndpoints struct {
+	TokenURL      string
+	AuthURL       string
+	DeviceAuthURL string
+}
+
+// DiscoverEndpointsWithDevice discovers token, authorization and device authorization endpoints.
+func (n *SamNode) DiscoverEndpointsWithDevice(ctx context.Context, issuerURL string) (*OIDCEndpoints, error) {
 	client := &http.Client{Timeout: oidcDiscoveryTimeout}
 	provider, err := oidc.NewProvider(oidc.ClientContext(ctx, client), issuerURL)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create OIDC provider: %w", err)
+		return nil, fmt.Errorf("failed to create OIDC provider: %w", err)
 	}
 	var claims struct {
-		TokenURL string `json:"token_endpoint"`
-		AuthURL  string `json:"authorization_endpoint"`
+		TokenURL      string `json:"token_endpoint"`
+		AuthURL       string `json:"authorization_endpoint"`
+		DeviceAuthURL string `json:"device_authorization_endpoint"`
 	}
 	if err := provider.Claims(&claims); err != nil {
-		return "", "", fmt.Errorf("failed to extract claims: %w", err)
+		return nil, fmt.Errorf("failed to extract claims: %w", err)
 	}
-	return claims.TokenURL, claims.AuthURL, nil
+	return &OIDCEndpoints{
+		TokenURL:      claims.TokenURL,
+		AuthURL:       claims.AuthURL,
+		DeviceAuthURL: claims.DeviceAuthURL,
+	}, nil
 }
 
 var openBrowserFunc = openBrowser
 
-func openBrowser(targetURL string) {
+func openBrowser(targetURL string) error {
 	parsedURL, err := url.Parse(targetURL)
 	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
-		logger.Debugf("Failed to open browser: invalid or unsafe URL scheme %q", targetURL)
-		return
+		return fmt.Errorf("invalid or unsafe URL scheme %q", targetURL)
 	}
 	var cmdErr error
 	switch runtime.GOOS {
@@ -364,7 +637,9 @@ func openBrowser(targetURL string) {
 	}
 	if cmdErr != nil {
 		logger.Debugf("Failed to open browser: %v", cmdErr)
+		return cmdErr
 	}
+	return nil
 }
 
 // RefreshJWT refreshes the OIDC token using the stored refresh token.

--- a/internal/node/oidc.go
+++ b/internal/node/oidc.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/mattn/go-isatty"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -378,11 +379,8 @@ func (n *SamNode) InteractiveLoginWithMode(ctx context.Context, authURL, tokenUR
 }
 
 func stdinIsInteractive() bool {
-	fi, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return (fi.Mode() & os.ModeCharDevice) != 0
+	fd := os.Stdin.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
 }
 
 // DeviceLogin performs OAuth 2.0 Device Authorization Grant (RFC 8628).
@@ -505,7 +503,15 @@ func (n *SamNode) DeviceLogin(ctx context.Context, deviceAuthURL, tokenURL, clie
 
 		tokenResp, err := client.Do(tokenReq)
 		if err != nil {
-			return "", fmt.Errorf("token polling request failed: %w", err)
+			// Transient network errors shouldn't abort the whole device flow: log
+			// and keep polling until the context is cancelled or the code expires.
+			logger.Warnf("Token polling request failed: %v. Retrying in %v...", err, pollInterval)
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(pollInterval):
+			}
+			continue
 		}
 
 		body, readErr := io.ReadAll(tokenResp.Body)

--- a/internal/node/oidc.go
+++ b/internal/node/oidc.go
@@ -61,23 +61,90 @@ func (n *SamNode) FetchJWT(ctx context.Context, tokenURL, clientID, clientSecret
 	return token.AccessToken, nil
 }
 
+// AuthMode selects how interactive enrollment authenticates the user.
+type AuthMode string
+
+const (
+	// AuthModeAuto prefers device flow in headless environments (when the
+	// provider advertises one) and the loopback browser flow otherwise, with an
+	// automatic device fallback when the browser can't be opened.
+	AuthModeAuto AuthMode = "auto"
+	// AuthModeDevice forces the OAuth 2.0 Device Authorization Grant (RFC 8628).
+	AuthModeDevice AuthMode = "device"
+	// AuthModeOOB forces the out-of-band code-paste flow.
+	AuthModeOOB AuthMode = "oob"
+	// AuthModeBrowser forces the loopback browser (authorization code) flow.
+	AuthModeBrowser AuthMode = "browser"
+)
+
+// ParseAuthMode validates a user-provided --auth-mode value. An empty string
+// maps to AuthModeAuto.
+func ParseAuthMode(s string) (AuthMode, error) {
+	switch AuthMode(strings.ToLower(strings.TrimSpace(s))) {
+	case "", AuthModeAuto:
+		return AuthModeAuto, nil
+	case AuthModeDevice:
+		return AuthModeDevice, nil
+	case AuthModeOOB:
+		return AuthModeOOB, nil
+	case AuthModeBrowser:
+		return AuthModeBrowser, nil
+	default:
+		return "", fmt.Errorf("invalid auth mode %q (want auto, device, oob, or browser)", s)
+	}
+}
+
 // InteractiveLogin prompts the user to go to a URL and enter a code.
 func (n *SamNode) InteractiveLogin(ctx context.Context, authURL, tokenURL, clientID, audience string, requestRefresh bool, headless bool) (string, error) {
 	return n.InteractiveLoginWithDeviceAuth(ctx, authURL, tokenURL, "", clientID, audience, requestRefresh, headless)
 }
 
-// InteractiveLoginWithDeviceAuth prompts the user to authenticate, preferring
-// OAuth Device Authorization Grant in headless mode when the provider exposes
-// a device authorization endpoint.
+// InteractiveLoginWithDeviceAuth authenticates using AuthModeAuto: it prefers
+// the OAuth Device Authorization Grant in headless mode when the provider
+// exposes a device authorization endpoint, and otherwise uses the loopback
+// browser flow with a device fallback.
 func (n *SamNode) InteractiveLoginWithDeviceAuth(ctx context.Context, authURL, tokenURL, deviceAuthURL, clientID, audience string, requestRefresh bool, headless bool) (string, error) {
-	if authURL == "" {
-		return "", fmt.Errorf("authorization URL is required")
-	}
+	return n.InteractiveLoginWithMode(ctx, authURL, tokenURL, deviceAuthURL, clientID, audience, requestRefresh, headless, AuthModeAuto)
+}
+
+// InteractiveLoginWithMode authenticates the user using an explicit AuthMode,
+// letting callers (e.g. CUJ harnesses) force a deterministic flow instead of
+// relying on headless environment detection.
+func (n *SamNode) InteractiveLoginWithMode(ctx context.Context, authURL, tokenURL, deviceAuthURL, clientID, audience string, requestRefresh bool, headless bool, mode AuthMode) (string, error) {
 	if tokenURL == "" {
 		return "", fmt.Errorf("token URL is required")
 	}
 	if clientID == "" {
 		return "", fmt.Errorf("client ID is required")
+	}
+
+	isHeadless := headless || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != ""
+
+	switch mode {
+	case AuthModeDevice:
+		if deviceAuthURL == "" {
+			return "", fmt.Errorf("auth-mode=device requested but the OIDC provider does not advertise a device_authorization_endpoint")
+		}
+		return n.DeviceLogin(ctx, deviceAuthURL, tokenURL, clientID, audience, requestRefresh)
+	case AuthModeOOB:
+		// Force out-of-band paste; disable any device fallback.
+		isHeadless = true
+		deviceAuthURL = ""
+	case AuthModeBrowser:
+		// Force the loopback browser flow; disable device fallback.
+		isHeadless = false
+		deviceAuthURL = ""
+	case AuthModeAuto:
+		if isHeadless && deviceAuthURL != "" {
+			logger.Info("Headless mode detected and device authorization endpoint available; using device flow")
+			return n.DeviceLogin(ctx, deviceAuthURL, tokenURL, clientID, audience, requestRefresh)
+		}
+	default:
+		return "", fmt.Errorf("invalid auth mode %q", mode)
+	}
+
+	if authURL == "" {
+		return "", fmt.Errorf("authorization URL is required")
 	}
 
 	stateBytes := make([]byte, 16)
@@ -89,13 +156,6 @@ func (n *SamNode) InteractiveLoginWithDeviceAuth(ctx context.Context, authURL, t
 	verifier, challenge, err := generatePKCE()
 	if err != nil {
 		return "", fmt.Errorf("failed to generate PKCE: %w", err)
-	}
-
-	isHeadless := headless || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != ""
-
-	if isHeadless && deviceAuthURL != "" {
-		logger.Info("Headless mode detected and device authorization endpoint available; using device flow")
-		return n.DeviceLogin(ctx, deviceAuthURL, tokenURL, clientID, audience, requestRefresh)
 	}
 
 	var redirectURI string

--- a/internal/node/oidc_test.go
+++ b/internal/node/oidc_test.go
@@ -453,6 +453,187 @@ func TestInteractiveLoginBrowserFailFallsBackToDevice(t *testing.T) {
 	}
 }
 
+func TestParseAuthMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    AuthMode
+		wantErr bool
+	}{
+		{"", AuthModeAuto, false},
+		{"auto", AuthModeAuto, false},
+		{"AUTO", AuthModeAuto, false},
+		{" device ", AuthModeDevice, false},
+		{"oob", AuthModeOOB, false},
+		{"browser", AuthModeBrowser, false},
+		{"nonsense", "", true},
+	}
+	for _, tc := range cases {
+		got, err := ParseAuthMode(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("ParseAuthMode(%q): expected error, got %q", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseAuthMode(%q): unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseAuthMode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestAuthModeDeviceForcedWhenInteractive verifies that auth-mode=device uses
+// the device flow even in a non-headless environment, and never touches the
+// browser.
+func TestAuthModeDeviceForcedWhenInteractive(t *testing.T) {
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_code":      "dev_code_1",
+			"user_code":        "AAAA-BBBB",
+			"verification_uri": "https://example.com/device",
+			"expires_in":       60,
+			"interval":         1,
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+			http.Error(w, "Invalid grant_type", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id_token": "forced_device_token"})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	originalOpenBrowser := openBrowserFunc
+	openBrowserFunc = func(_ string) error {
+		t.Error("openBrowser should not be called when auth-mode=device")
+		return nil
+	}
+	defer func() { openBrowserFunc = originalOpenBrowser }()
+
+	token, err := node.InteractiveLoginWithMode(
+		ctx,
+		"http://auth.example.com/auth",
+		server.URL+"/token",
+		server.URL+"/device",
+		"client_id_test",
+		"sam-e2e",
+		false,
+		false,
+		AuthModeDevice,
+	)
+	if err != nil {
+		t.Fatalf("InteractiveLoginWithMode failed: %v", err)
+	}
+	if token != "forced_device_token" {
+		t.Fatalf("Expected forced_device_token, got %q", token)
+	}
+}
+
+// TestAuthModeDeviceWithoutEndpointErrors verifies that auth-mode=device fails
+// fast when the provider advertises no device endpoint.
+func TestAuthModeDeviceWithoutEndpointErrors(t *testing.T) {
+	node := &SamNode{}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := node.InteractiveLoginWithMode(
+		ctx,
+		"http://auth.example.com/auth",
+		"http://token.example.com/token",
+		"", // no device endpoint
+		"client_id_test",
+		"sam-e2e",
+		false,
+		true,
+		AuthModeDevice,
+	)
+	if err == nil {
+		t.Fatal("expected an error when auth-mode=device but no device endpoint is available")
+	}
+	if !strings.Contains(err.Error(), "device_authorization_endpoint") {
+		t.Fatalf("expected device endpoint error, got: %v", err)
+	}
+}
+
+// TestAuthModeBrowserIgnoresDevice verifies that auth-mode=browser uses the
+// loopback flow even under a headless (SSH) environment with a device
+// endpoint available, and never falls back to device flow.
+func TestAuthModeBrowserIgnoresDevice(t *testing.T) {
+	t.Setenv("SSH_CLIENT", "1")
+	t.Setenv("SSH_TTY", "")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("device endpoint should not be used when auth-mode=browser")
+		http.Error(w, "unexpected", http.StatusBadRequest)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "authorization_code" {
+			http.Error(w, "Invalid grant_type", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id_token": "browser_mode_token"})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	originalOpenBrowser := openBrowserFunc
+	openBrowserFunc = func(urlStr string) error {
+		u, _ := url.Parse(urlStr)
+		redirectURI := u.Query().Get("redirect_uri")
+		state := u.Query().Get("state")
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			_, _ = http.Get(redirectURI + "?code=dev_code_123&state=" + state)
+		}()
+		return nil
+	}
+	defer func() { openBrowserFunc = originalOpenBrowser }()
+
+	token, err := node.InteractiveLoginWithMode(
+		ctx,
+		"http://auth.example.com/auth",
+		server.URL+"/token",
+		server.URL+"/device",
+		"client_id_test",
+		"sam-e2e",
+		false,
+		true, // headless requested, but browser mode overrides it
+		AuthModeBrowser,
+	)
+	if err != nil {
+		t.Fatalf("InteractiveLoginWithMode failed: %v", err)
+	}
+	if token != "browser_mode_token" {
+		t.Fatalf("Expected browser_mode_token, got %q", token)
+	}
+}
+
 func TestRenewWithRefreshToken(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/node/oidc_test.go
+++ b/internal/node/oidc_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -450,6 +451,62 @@ func TestInteractiveLoginBrowserFailFallsBackToDevice(t *testing.T) {
 	}
 	if token != "id_token_after_browser_fail" {
 		t.Fatalf("Expected id_token_after_browser_fail, got %q", token)
+	}
+}
+
+// TestDeviceLoginRetriesOnTransientTokenError verifies that a transient
+// network error while polling the token endpoint doesn't abort the device
+// flow: DeviceLogin should log a warning, wait for the next poll interval,
+// and keep polling until it succeeds (or the context/expiry ends it).
+func TestDeviceLoginRetriesOnTransientTokenError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_code":      "dev_code_1",
+			"user_code":        "AAAA-BBBB",
+			"verification_uri": "https://example.com/device",
+			"expires_in":       60,
+			"interval":         1,
+		})
+	})
+
+	var pollCount int32
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&pollCount, 1) == 1 {
+			// Simulate a transient network error on the first poll by closing
+			// the connection without writing a response.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("ResponseWriter does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("failed to hijack connection: %v", err)
+			}
+			_ = conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id_token": "token_after_retry"})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	token, err := node.DeviceLogin(ctx, server.URL+"/device", server.URL+"/token", "client_id_test", "sam-e2e", false)
+	if err != nil {
+		t.Fatalf("DeviceLogin failed: %v", err)
+	}
+	if token != "token_after_retry" {
+		t.Fatalf("Expected token_after_retry, got %q", token)
+	}
+	if got := atomic.LoadInt32(&pollCount); got < 2 {
+		t.Fatalf("expected at least 2 poll attempts, got %d", got)
 	}
 }
 

--- a/internal/node/oidc_test.go
+++ b/internal/node/oidc_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -56,7 +57,7 @@ func TestInteractiveLogin(t *testing.T) {
 
 	// Mock openBrowser to simulate the user authorizing in the browser
 	originalOpenBrowser := openBrowserFunc
-	openBrowserFunc = func(urlStr string) {
+	openBrowserFunc = func(urlStr string) error {
 		u, _ := url.Parse(urlStr)
 		redirectURI := u.Query().Get("redirect_uri")
 		state := u.Query().Get("state")
@@ -65,6 +66,7 @@ func TestInteractiveLogin(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 			_, _ = http.Get(redirectURI + "?code=dev_code_123&state=" + state)
 		}()
+		return nil
 	}
 	defer func() { openBrowserFunc = originalOpenBrowser }()
 
@@ -107,6 +109,42 @@ func TestDiscoverEndpoints(t *testing.T) {
 	}
 	if authURL != server.URL+"/auth" {
 		t.Errorf("Expected authURL %s, got %s", server.URL+"/auth", authURL)
+	}
+}
+
+func TestDiscoverEndpointsWithDevice(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                        "http://" + r.Host,
+			"token_endpoint":                "http://" + r.Host + "/token",
+			"authorization_endpoint":        "http://" + r.Host + "/auth",
+			"device_authorization_endpoint": "http://" + r.Host + "/device",
+		}); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{BiscuitTimeout: 500 * time.Millisecond}
+	ctx := context.Background()
+
+	endpoints, err := node.DiscoverEndpointsWithDevice(ctx, server.URL)
+	if err != nil {
+		t.Fatalf("DiscoverEndpointsWithDevice failed: %v", err)
+	}
+
+	if endpoints.TokenURL != server.URL+"/token" {
+		t.Errorf("Expected tokenURL %s, got %s", server.URL+"/token", endpoints.TokenURL)
+	}
+	if endpoints.AuthURL != server.URL+"/auth" {
+		t.Errorf("Expected authURL %s, got %s", server.URL+"/auth", endpoints.AuthURL)
+	}
+	if endpoints.DeviceAuthURL != server.URL+"/device" {
+		t.Errorf("Expected deviceAuthURL %s, got %s", server.URL+"/device", endpoints.DeviceAuthURL)
 	}
 }
 
@@ -193,7 +231,7 @@ func TestInteractiveLoginWithRefresh(t *testing.T) {
 	defer cancel()
 
 	originalOpenBrowser := openBrowserFunc
-	openBrowserFunc = func(urlStr string) {
+	openBrowserFunc = func(urlStr string) error {
 		u, _ := url.Parse(urlStr)
 		redirectURI := u.Query().Get("redirect_uri")
 		state := u.Query().Get("state")
@@ -211,6 +249,7 @@ func TestInteractiveLoginWithRefresh(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 			_, _ = http.Get(redirectURI + "?code=dev_code_123&state=" + state)
 		}()
+		return nil
 	}
 	defer func() { openBrowserFunc = originalOpenBrowser }()
 
@@ -230,6 +269,187 @@ func TestInteractiveLoginWithRefresh(t *testing.T) {
 	}
 	if savedRefresh != "refresh_token_123" {
 		t.Errorf("Expected saved refresh token 'refresh_token_123', got '%s'", savedRefresh)
+	}
+}
+
+func TestInteractiveLoginWithDeviceAuth_Headless(t *testing.T) {
+	t.Setenv("SSH_CLIENT", "1")
+	t.Setenv("SSH_TTY", "")
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseForm()
+		if r.FormValue("client_id") != "client_id_test" {
+			http.Error(w, "Invalid client_id", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_code":               "dev_code_1",
+			"user_code":                 "ABCD-EFGH",
+			"verification_uri":          "https://example.com/device",
+			"verification_uri_complete": "https://example.com/device?user_code=ABCD-EFGH",
+			"expires_in":                60,
+			"interval":                  1,
+		})
+	})
+
+	pollCount := 0
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+			http.Error(w, "Invalid grant_type", http.StatusBadRequest)
+			return
+		}
+		pollCount++
+		w.Header().Set("Content-Type", "application/json")
+		if pollCount < 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error":             "authorization_pending",
+				"error_description": "waiting",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id_token":      "id_token_from_device",
+			"refresh_token": "refresh_from_device",
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("failed to close store: %v", err)
+		}
+	}()
+
+	node := &SamNode{Store: store}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	originalOpenBrowser := openBrowserFunc
+	openBrowserFunc = func(_ string) error {
+		t.Error("openBrowser should not be called when device flow is used")
+		return nil
+	}
+	defer func() { openBrowserFunc = originalOpenBrowser }()
+
+	token, err := node.InteractiveLoginWithDeviceAuth(
+		ctx,
+		"http://auth.example.com/auth",
+		server.URL+"/token",
+		server.URL+"/device",
+		"client_id_test",
+		"sam-e2e",
+		true,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("InteractiveLoginWithDeviceAuth failed: %v", err)
+	}
+	if token != "id_token_from_device" {
+		t.Fatalf("Expected id_token_from_device, got %q", token)
+	}
+
+	savedRefresh, err := store.LoadRefreshToken()
+	if err != nil {
+		t.Fatalf("Failed to load refresh token: %v", err)
+	}
+	if savedRefresh != "refresh_from_device" {
+		t.Fatalf("Expected refresh_from_device, got %q", savedRefresh)
+	}
+}
+
+// TestInteractiveLoginBrowserFailFallsBackToDevice verifies that in an
+// interactive (non-headless) flow, if the browser cannot be opened, SAM falls
+// back to the device authorization flow when the provider advertises one,
+// instead of leaving the user to paste a callback code.
+func TestInteractiveLoginBrowserFailFallsBackToDevice(t *testing.T) {
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseForm()
+		if r.FormValue("client_id") != "client_id_test" {
+			http.Error(w, "Invalid client_id", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_code":      "dev_code_1",
+			"user_code":        "WXYZ-1234",
+			"verification_uri": "https://example.com/device",
+			"expires_in":       60,
+			"interval":         1,
+		})
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+			http.Error(w, "Invalid grant_type", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id_token": "id_token_after_browser_fail",
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	node := &SamNode{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	originalOpenBrowser := openBrowserFunc
+	openBrowserFunc = func(_ string) error {
+		return fmt.Errorf("no browser available")
+	}
+	defer func() { openBrowserFunc = originalOpenBrowser }()
+
+	token, err := node.InteractiveLoginWithDeviceAuth(
+		ctx,
+		"http://auth.example.com/auth",
+		server.URL+"/token",
+		server.URL+"/device",
+		"client_id_test",
+		"sam-e2e",
+		false,
+		false, // interactive: browser flow attempted first, then device fallback
+	)
+	if err != nil {
+		t.Fatalf("InteractiveLoginWithDeviceAuth failed: %v", err)
+	}
+	if token != "id_token_after_browser_fail" {
+		t.Fatalf("Expected id_token_after_browser_fail, got %q", token)
 	}
 }
 

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -91,7 +91,7 @@ sam-node is running in the background.
   Stop      kill 48213
 ```
 
-If no API token is configured (`SAM_API_TOKEN` or `--api-token-path`), `--daemonize` generates one under the data directory and reuses it on later starts. The command is idempotent: re-run it to confirm a node is up. Enrollment still needs a one-time login, so on a node with no identity it tells you to run `sam-node join --headless <control-plane-url>` first.
+If no API token is configured (`SAM_API_TOKEN` or `--api-token-path`), `--daemonize` generates one under the data directory and reuses it on later starts. The command is idempotent: re-run it to confirm a node is up. Enrollment still needs a one-time login, so on a node with no identity it tells you to run `sam-node join --headless <control-plane-url>` first. In headless mode, SAM prefers OAuth device flow automatically when the provider supports it, and falls back to OOB code-paste only when needed.
 
 #### Starting Over
 

--- a/site/content/docs/user/agent-usage.md
+++ b/site/content/docs/user/agent-usage.md
@@ -58,6 +58,14 @@ sam-node join https://bananas.sam-mesh.dev --headless
 ```
 When the OIDC provider supports device authorization, SAM automatically uses device flow (no pasted callback code required): it prints a verification URL/code and polls until approval. If device authorization is unavailable, SAM falls back to OOB code-paste flow.
 
+### Choosing the Auth Flow Explicitly
+By default (`--auth-mode auto`) SAM picks the flow for you: device flow in headless environments when available, the loopback browser flow otherwise (with an automatic device fallback if the browser can't be opened). For deterministic automation (e.g. CI/CUJ harnesses), force a specific flow instead of relying on environment detection:
+```bash
+# Force RFC 8628 device flow (no code to paste back)
+sam-node join https://bananas.sam-mesh.dev --auth-mode device
+```
+Supported values: `auto` (default), `device`, `oob`, `browser`. `--auth-mode device` fails fast if the provider does not advertise a `device_authorization_endpoint`.
+
 ### Automatic Token Renewal
 To allow long-lived nodes to automatically renew their tokens in the background, request offline access (refreshes the OIDC session):
 ```bash

--- a/site/content/docs/user/agent-usage.md
+++ b/site/content/docs/user/agent-usage.md
@@ -56,7 +56,7 @@ If you are running the node on a remote server via SSH (without a web browser), 
 ```bash
 sam-node join https://bananas.sam-mesh.dev --headless
 ```
-The CLI will print a verification URL and code (e.g. `https://google.com/device` and `ABCD-EFGH`). Open this URL on your local laptop, enter the code, complete the login, and the remote terminal session will activate automatically.
+When the OIDC provider supports device authorization, SAM automatically uses device flow (no pasted callback code required): it prints a verification URL/code and polls until approval. If device authorization is unavailable, SAM falls back to OOB code-paste flow.
 
 ### Automatic Token Renewal
 To allow long-lived nodes to automatically renew their tokens in the background, request offline access (refreshes the OIDC session):

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -37,7 +37,10 @@ teardown() {
   
   [[ -n "${token}" ]]
 
-  # 2. Run sam-node join to enroll and store identity
+  # 2. Run sam-node join to enroll and store identity. The sam-node image has
+  # no browser to open, so the loopback flow can't complete; join falls back
+  # to the OAuth 2.0 Device Authorization Grant (RFC 8628), which the mock
+  # OIDC provider advertises and auto-approves on the first poll.
   local node_name="${MESH_PREFIX}-node-login"
   local router_peer_id
   router_peer_id=$(cat "/tmp/${MESH_PREFIX}-router-peer-id")
@@ -45,49 +48,26 @@ teardown() {
   local data_vol="${MESH_PREFIX}-data"
   docker volume create "${data_vol}"
   CLEANUP_VOLUMES+=("${data_vol}")
-  
-  docker run --name "${node_name}-join" \
+
+  docker run -d --name "${node_name}-join" \
     --network "${MESH_NETWORK}" \
     $(mesh_get_add_hosts) \
     -v "${data_vol}:/data" \
     "sam-node:local" \
-    join --data-dir /data "http://sam-control-plane:8080" > "/tmp/${node_name}-join.out" 2>&1 &
-  local join_pid=$!
+    join --data-dir /data "http://sam-control-plane:8080"
   MESH_CONTAINERS+=("${node_name}-join")
 
-  # Wait for redirect_uri and state in the output
-  local redirect_uri=""
-  local state=""
-  local port=""
-  for i in {1..20}; do
-    if grep -q "redirect_uri=" "/tmp/${node_name}-join.out"; then
-      # Output format: http://mock-oidc...redirect_uri=http%3A%2F%2F127.0.0.1%3A<PORT>%2Fcallback&...&state=<STATE>
-      local line
-      line=$(grep "redirect_uri=" "/tmp/${node_name}-join.out" | head -n 1)
-      redirect_uri=$(echo "$line" | grep -o 'redirect_uri=[^&]*' | cut -d= -f2 | tr -d '\r\n')
-      state=$(echo "$line" | grep -o 'state=[^&]*' | cut -d= -f2 | tr -d '\r\n')
-      
-      # URL decode redirect_uri
-      # e.g. http%3A%2F%2F127.0.0.1%3A41353%2Fcallback -> http://127.0.0.1:41353/callback
-      redirect_uri=$(echo "$redirect_uri" | sed -e 's/%3A/:/g' -e 's/%2F/\//g')
-      
-      port=$(echo "$redirect_uri" | grep -o ':[0-9]*' | tr -d ':\r\n')
-      if [[ -n "$port" && -n "$state" ]]; then
-        break
-      fi
-    fi
-    sleep 1
-  done
+  run mesh_wait_for_log "${node_name}-join" "OAuth Device Authorization Flow" 20
+  [[ "$status" -eq 0 ]]
+  run mesh_wait_for_log "${node_name}-join" "Enter code: ABCD-1234" 20
+  [[ "$status" -eq 0 ]]
 
-  [[ -n "$port" ]] && [[ -n "$state" ]]
-
-  # Trigger the callback in the sam-node container's network namespace
-  docker run --rm --network "container:${node_name}-join" python:3.12 python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${port}/callback?code=dev_code_123&state=${state}')"
-
-  # Wait for the join process to finish
-  wait $join_pid
+  # Wait for the join process to finish and check it succeeded.
+  run mesh_wait_for_log "${node_name}-join" "Successfully joined the Sovereign Agent Mesh!" 20
+  [[ "$status" -eq 0 ]]
+  [[ "$(docker inspect -f '{{.State.ExitCode}}' "${node_name}-join")" -eq 0 ]]
   docker rm -f "${node_name}-join" >/dev/null 2>&1 || true
-    
+
   # Now run the node with the stored identity
   docker run -d \
     --name "${node_name}" \


### PR DESCRIPTION
… fallback

Headless 'join' now prefers the OAuth 2.0 Device Authorization Grant (RFC 8628) when the OIDC provider advertises a device_authorization_endpoint, so CUJ harnesses and no-browser hosts no longer have to paste a callback code back. OOB code-paste remains as a fallback when no device endpoint is available.

In interactive mode, if the browser can't be opened (or the loopback listener can't bind), SAM falls back to device flow when the provider supports it instead of leaving the user to paste a code.

Wires device-endpoint discovery through sam-node and sam-box join flows, updates the sam-mesh skill and user docs, and adds unit tests for device discovery, headless device login, and the browser-failure fallback.