### PR TITLE
console: return users from /admin/status

### DIFF
--- a/cmd/sam-console/public/app.js
+++ b/cmd/sam-console/public/app.js
@@ -185,8 +185,8 @@ function renderUsersTable(users) {
         <tr>
             <td><code>${escapeHTML(user.ID)}</code></td>
             <td>${escapeHTML(user.Role)}</td>
-            <td>${escapeHTML(user.Name)}</td>
             <td>${escapeHTML(user.Email)}</td>
+            <td>${new Date(user.CreatedAt).toLocaleString()}</td>
         </tr>
     `).join('');
 }

--- a/cmd/sam-console/public/index.html
+++ b/cmd/sam-console/public/index.html
@@ -159,10 +159,10 @@
                         <table class="data-table">
                             <thead>
                                 <tr>
-                                    <th>ID</th>
                                     <th>Subject (OIDC)</th>
-                                    <th>Name</th>
+                                    <th>Role</th>
                                     <th>Email</th>
+                                    <th>Created</th>
                                 </tr>
                             </thead>
                             <tbody id="table-users">

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -970,6 +970,16 @@ func TestAdminPanelAndUI(t *testing.T) {
 
 	srv.config.AdminToken = "test-admin-pass"
 
+	testUser := &storage.User{
+		ID:        "oidc-sub-123",
+		Email:     "user@example.com",
+		Role:      "user",
+		CreatedAt: time.Now(),
+	}
+	if err := store.SaveUser(context.Background(), testUser); err != nil {
+		t.Fatalf("failed to save test user: %v", err)
+	}
+
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	// 1. Query /admin/status without token -> should fail with 401
@@ -1010,6 +1020,13 @@ func TestAdminPanelAndUI(t *testing.T) {
 	}
 	if _, ok := statusData["bootstrap_tokens"]; !ok {
 		t.Error("status response missing bootstrap_tokens")
+	}
+	users, ok := statusData["users"].([]any)
+	if !ok || len(users) != 1 {
+		t.Fatalf("expected 1 user in status response, got: %v", statusData["users"])
+	}
+	if got := users[0].(map[string]any)["ID"]; got != testUser.ID {
+		t.Errorf("expected user ID %q, got %v", testUser.ID, got)
 	}
 
 	// 3. Query /admin/ UI page -> should fail with 404 as it is removed

--- a/internal/controlplane/ui.go
+++ b/internal/controlplane/ui.go
@@ -62,6 +62,13 @@ func (s *Server) HandleAdminStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	users, err := s.store.ListUsers(ctx)
+	if err != nil {
+		logger.Errorf("Failed to list users: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
 	roles, bindings, err := s.store.GetMeshPolicy(r.Context())
 	if err != nil {
 		logger.Errorf("Failed to list policy: %v", err)
@@ -100,6 +107,7 @@ func (s *Server) HandleAdminStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
+		"users":               users,
 		"active_routers":      routers,
 		"enrolled_nodes":      nodes,
 		"enrollment_requests": reqs,


### PR DESCRIPTION
Fixes #275

The console reads `data.users` to fill the "Active Users" tile and the Users
table, but `/admin/status` never included a `users` key, so both were always
empty. `storage.ListUsers` existed with no callers.

Adds the users list to the `/admin/status` response.

The table also rendered `user.Role` under a "Subject (OIDC)" header and a
`user.Name` field that `storage.User` does not have. Columns are now
Subject (OIDC) | Role | Email | Created — `User.ID` is the OIDC `sub`.
