### PR TITLE
fix(site): restore scrolling so the landing demo stays reachable

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -31,7 +31,8 @@
   justify-content: center;
   align-items: center;
   position: relative;
-  overflow: hidden;
+  overflow-x: hidden;
+
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 
   // Ambient mesh network grid background
@@ -259,6 +260,14 @@
         transform: translateY(0);
       }
     }
+  }
+
+  #demo-player {
+    width: 100%;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5), 0 0 40px rgba(0, 240, 255, 0.1);
+    border: 1px solid rgba(0, 240, 255, 0.15);
   }
 
   // Terminal Window Styling

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -32,6 +32,7 @@
   align-items: center;
   position: relative;
   overflow-x: hidden;
+  align-items: safe center;
 
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -28,7 +28,7 @@
     <!-- Bottom Row: Demo Player -->
     <link rel="stylesheet" href="{{ "vendor/asciinema-player/asciinema-player.css" | relURL }}">
     <div style="width: 100%;">
-      <div id="demo-player" data-cast="{{ "demo.cast" | relURL }}" style="border-radius: 12px; overflow: hidden; box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5), 0 0 40px rgba(0, 240, 255, 0.1); border: 1px solid rgba(0, 240, 255, 0.15);"></div>
+      <div id="demo-player" data-cast="{{ "demo.cast" | relURL }}"></div>
     </div>
     <script src="{{ "vendor/asciinema-player/asciinema-player.min.js" | relURL }}"></script>
     <script>
@@ -39,7 +39,7 @@
         autoPlay: true,
         loop: true,
         preload: true,
-        fit: 'width'
+        fit: 'width' // fill the container width; height follows the terminal
       });
     </script>
   </div>


### PR DESCRIPTION
## What

Hello! This is a fix to the landing page demo being cut off at the bottom and unreachable.
The bottom of the demo was clipped out due to `overflow: hidden` on the body even on scroll.

## Changes

- `overflow: hidden` → `overflow-x: hidden` — restores vertical scrolling
- Demo card styles moved from inline HTML into the landing SCSS


| Before | After (scrolled down) |
| :---: | :---: |
| <img width="1920" height="956" alt="image" src="https://github.com/user-attachments/assets/d9fa1c82-8d1d-4f24-87ab-9ef4b7f29ae0" /> | <img width="1915" height="959" alt="image" src="https://github.com/user-attachments/assets/889da0c6-c1c5-47fa-8f18-203fc2855556" /> |