### PR TITLE
fix(console): serve the routes under --base-path, not just at the root

### DIFF
--- a/cmd/sam-console/main.go
+++ b/cmd/sam-console/main.go
@@ -36,7 +36,7 @@ func main() {
 		ControlPlaneURL: *controlPlaneURL,
 		AdminToken:      adminToken,
 		StaticDir:       *staticDir,
-		BasePath:        *basePath,
+		BasePath:        console.NormalizeBasePath(*basePath),
 	})
 	if err != nil {
 		log.Fatalf("Failed to initialize console server: %v", err)

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -26,6 +27,19 @@ type Config struct {
 	AdminToken      string
 	StaticDir       string
 	BasePath        string
+}
+
+// NormalizeBasePath makes a base-path flag value safe to concatenate: no trailing
+// slash (else cookie paths become /console//) and a guaranteed leading slash.
+func NormalizeBasePath(p string) string {
+	if p == "" {
+		return ""
+	}
+	p = path.Clean("/" + p)
+	if p == "/" {
+		return ""
+	}
+	return p
 }
 
 type Server struct {
@@ -101,12 +115,14 @@ func NewServer(cfg Config) (*Server, error) {
 		},
 	}
 
+	routes := http.NewServeMux()
+
 	// Proxy all API requests to the control plane
-	s.mux.Handle("/api/", http.StripPrefix("/api", proxy))
+	routes.Handle("/api/", http.StripPrefix("/api", proxy))
 
 	// Serve static files
 	fs := http.FileServer(http.Dir(s.cfg.StaticDir))
-	s.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	routes.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Basic check if file exists
 		path := filepath.Join(s.cfg.StaticDir, r.URL.Path)
 		if _, err := os.Stat(path); os.IsNotExist(err) && r.URL.Path != "/" {
@@ -119,12 +135,19 @@ func NewServer(cfg Config) (*Server, error) {
 
 	// OIDC login endpoints
 	if s.provider != nil {
-		s.mux.HandleFunc("/auth/login", s.HandleLogin)
-		s.mux.HandleFunc("/auth/callback", s.HandleCallback)
-		s.mux.HandleFunc("/auth/session", s.HandleSession)
+		routes.HandleFunc("/auth/login", s.HandleLogin)
+		routes.HandleFunc("/auth/callback", s.HandleCallback)
+		routes.HandleFunc("/auth/session", s.HandleSession)
 	}
-	s.mux.HandleFunc("/auth/logout", s.HandleLogout)
-	s.mux.HandleFunc("/info", s.HandleInfo)
+	routes.HandleFunc("/auth/logout", s.HandleLogout)
+	routes.HandleFunc("/info", s.HandleInfo)
+
+	// Serve under BasePath too, so the links this server emits resolve without the proxy
+	// stripping the prefix. Still served at the root for proxies that do strip it.
+	if s.cfg.BasePath != "" {
+		s.mux.Handle(s.cfg.BasePath+"/", http.StripPrefix(s.cfg.BasePath, routes))
+	}
+	s.mux.Handle("/", routes)
 
 	return s, nil
 }

--- a/internal/console/server_test.go
+++ b/internal/console/server_test.go
@@ -243,3 +243,59 @@ func TestDiscoverProviderWithRetry(t *testing.T) {
 		}
 	})
 }
+
+// TestNewServer_BasePathServesBothPrefixes: with a BasePath the console must answer both the
+// prefixed URLs it hands out (so a proxy can forward /console/* untouched) and the root.
+func TestNewServer_BasePathServesBothPrefixes(t *testing.T) {
+	controlPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK) // empty /info: no OIDC, which the console tolerates
+	}))
+	defer controlPlane.Close()
+
+	srv, err := NewServer(Config{
+		ControlPlaneURL: controlPlane.URL,
+		AdminToken:      "test-admin-token",
+		StaticDir:       t.TempDir(),
+		BasePath:        "/console",
+	})
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+	console := httptest.NewServer(srv.Handler())
+	defer console.Close()
+
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	for path, want := range map[string]int{
+		"/info":         http.StatusOK,
+		"/console/info": http.StatusOK,
+		"/console":      http.StatusMovedPermanently, // ServeMux redirects to the subtree root
+	} {
+		resp, err := client.Get(console.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != want {
+			t.Errorf("GET %s: got %d, want %d", path, resp.StatusCode, want)
+		}
+	}
+}
+
+// BasePath is concatenated into cookie paths, redirect URLs and mux patterns, so malformed
+// flag values (trailing slash, missing leading slash) must be normalized where the flag is read.
+func TestNormalizeBasePath(t *testing.T) {
+	for input, want := range map[string]string{
+		"":               "",
+		"/":              "",
+		"/console":       "/console",
+		"/console/":      "/console",
+		"console":        "/console",
+		"console//":      "/console",
+		"//console":      "/console",
+		"/console//sub/": "/console/sub",
+	} {
+		if got := NormalizeBasePath(input); got != want {
+			t.Errorf("NormalizeBasePath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}


### PR DESCRIPTION
The console emits URLs that include its `--base-path` (cookie paths, OIDC redirect URIs, post-login redirects) but only mounts its routes at the root. Deploying it under a prefix (e.g. `/console/`) requires the proxy in front to strip the prefix back off. In Gateway API this is performed with a `HTTPRoute` `URLRewrite` filter.

`URLRewrite` path rewriting is **extended** conformance in Gateway API, not core, so it is optional and a given gateway implementation may not support it (`cloud-provider-kind` doesn't , tested locally)