### PR TITLE
fix(discovery): authorize exact-name GossipSub tool results

### DIFF
--- a/internal/node/mcp_handlers.go
+++ b/internal/node/mcp_handlers.go
@@ -424,6 +424,10 @@ func gossipToolRows(provs []samdiscovery.Provider, toolName, serviceNameFilter s
 // authorization evidence. Each candidate is confirmed through the existing
 // authenticated MCP session and exact tools/list response before it is exposed.
 func (n *SamNode) verifyGossipToolRows(ctx context.Context, candidates []remoteToolRow) []remoteToolRow {
+	if len(candidates) == 0 {
+		return nil
+	}
+
 	const maxConcurrent = 8
 
 	verifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/internal/node/mcp_handlers.go
+++ b/internal/node/mcp_handlers.go
@@ -424,14 +424,22 @@ func gossipToolRows(provs []samdiscovery.Provider, toolName, serviceNameFilter s
 // authorization evidence. Each candidate is confirmed through the existing
 // authenticated MCP session and exact tools/list response before it is exposed.
 func (n *SamNode) verifyGossipToolRows(ctx context.Context, candidates []remoteToolRow) []remoteToolRow {
+	return verifyGossipToolRowsWithFetcher(ctx, candidates, n.fetchRemoteToolDescription)
+}
+
+const (
+	gossipVerificationMaxConcurrent = 8
+	gossipVerificationTimeout       = 5 * time.Second
+)
+
+func verifyGossipToolRowsWithFetcher(
+	ctx context.Context,
+	candidates []remoteToolRow,
+	fetchDescription func(context.Context, peer.ID, string) (*remoteToolDescription, error),
+) []remoteToolRow {
 	if len(candidates) == 0 {
 		return nil
 	}
-
-	const maxConcurrent = 8
-
-	verifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
 
 	type verificationResult struct {
 		row remoteToolRow
@@ -440,8 +448,8 @@ func (n *SamNode) verifyGossipToolRows(ctx context.Context, candidates []remoteT
 	results := make([]verificationResult, len(candidates))
 	jobs := make(chan int)
 	workerCount := len(candidates)
-	if workerCount > maxConcurrent {
-		workerCount = maxConcurrent
+	if workerCount > gossipVerificationMaxConcurrent {
+		workerCount = gossipVerificationMaxConcurrent
 	}
 
 	var wg sync.WaitGroup
@@ -451,6 +459,8 @@ func (n *SamNode) verifyGossipToolRows(ctx context.Context, candidates []remoteT
 			defer wg.Done()
 			for {
 				select {
+				case <-ctx.Done():
+					return
 				case index, ok := <-jobs:
 					if !ok {
 						return
@@ -461,7 +471,9 @@ func (n *SamNode) verifyGossipToolRows(ctx context.Context, candidates []remoteT
 						logger.Debugf("[find_remote_tools] invalid gossip peer %q skipped: %v", candidate.PeerID, err)
 						continue
 					}
-					description, err := n.fetchRemoteToolDescription(verifyCtx, pid, candidate.ToolName)
+					requestCtx, cancel := context.WithTimeout(ctx, gossipVerificationTimeout)
+					description, err := fetchDescription(requestCtx, pid, candidate.ToolName)
+					cancel()
 					if err != nil {
 						logger.Debugf("[find_remote_tools] unverified gossip candidate %s on %s skipped: %v", candidate.ToolName, pid, err)
 						continue
@@ -475,8 +487,6 @@ func (n *SamNode) verifyGossipToolRows(ctx context.Context, candidates []remoteT
 							Labels:      candidate.Labels,
 						},
 					}
-				case <-verifyCtx.Done():
-					return
 				}
 			}
 		}()
@@ -486,7 +496,7 @@ sendCandidates:
 	for index := range candidates {
 		select {
 		case jobs <- index:
-		case <-verifyCtx.Done():
+		case <-ctx.Done():
 			break sendCandidates
 		}
 	}

--- a/internal/node/mcp_handlers.go
+++ b/internal/node/mcp_handlers.go
@@ -339,7 +339,8 @@ func (n *SamNode) handleFindRemoteTools(ctx context.Context, req *mcp.CallToolRe
 	if params.ToolName != "" && params.PeerID == "" && n.Discovery != nil {
 		n.Discovery.Ensure(api.ServiceType_SERVICE_TYPE_MCP, params.ToolName)
 		if provs := n.Discovery.Providers(api.ServiceType_SERVICE_TYPE_MCP, params.ToolName); len(provs) > 0 {
-			rows = gossipToolRows(provs, params.ToolName, params.ServiceName)
+			candidates := gossipToolRows(provs, params.ToolName, params.ServiceName)
+			rows = n.verifyGossipToolRows(ctx, candidates)
 			if len(rows) > 0 {
 				return marshalToolRows(rows)
 			}
@@ -415,6 +416,84 @@ func gossipToolRows(provs []samdiscovery.Provider, toolName, serviceNameFilter s
 			ToolName: name + "/" + toolName,
 			Labels:   p.Labels,
 		})
+	}
+	return rows
+}
+
+// verifyGossipToolRows treats unsolicited announcements as routing hints, not
+// authorization evidence. Each candidate is confirmed through the existing
+// authenticated MCP session and exact tools/list response before it is exposed.
+func (n *SamNode) verifyGossipToolRows(ctx context.Context, candidates []remoteToolRow) []remoteToolRow {
+	const maxConcurrent = 8
+
+	verifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	type verificationResult struct {
+		row remoteToolRow
+		ok  bool
+	}
+	results := make([]verificationResult, len(candidates))
+	jobs := make(chan int)
+	workerCount := len(candidates)
+	if workerCount > maxConcurrent {
+		workerCount = maxConcurrent
+	}
+
+	var wg sync.WaitGroup
+	for range workerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case index, ok := <-jobs:
+					if !ok {
+						return
+					}
+					candidate := candidates[index]
+					pid, err := peer.Decode(candidate.PeerID)
+					if err != nil {
+						logger.Debugf("[find_remote_tools] invalid gossip peer %q skipped: %v", candidate.PeerID, err)
+						continue
+					}
+					description, err := n.fetchRemoteToolDescription(verifyCtx, pid, candidate.ToolName)
+					if err != nil {
+						logger.Debugf("[find_remote_tools] unverified gossip candidate %s on %s skipped: %v", candidate.ToolName, pid, err)
+						continue
+					}
+					results[index] = verificationResult{
+						ok: true,
+						row: remoteToolRow{
+							PeerID:      description.PeerID,
+							ToolName:    description.ToolName,
+							Description: description.Description,
+							Labels:      candidate.Labels,
+						},
+					}
+				case <-verifyCtx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+sendCandidates:
+	for index := range candidates {
+		select {
+		case jobs <- index:
+		case <-verifyCtx.Done():
+			break sendCandidates
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	rows := make([]remoteToolRow, 0, len(results))
+	for _, result := range results {
+		if result.ok {
+			rows = append(rows, result.row)
+		}
 	}
 	return rows
 }
@@ -592,6 +671,48 @@ type DescribeRemoteToolParams struct {
 	ToolName string `json:"tool_name" jsonschema:"Namespaced server name as returned by find_remote_tools (e.g. 'mcp://code-reviewer/review_pr'). Required."`
 }
 
+func (n *SamNode) fetchRemoteToolDescription(ctx context.Context, pid peer.ID, toolName string) (*remoteToolDescription, error) {
+	serviceName, actualToolName, err := api.SplitToolName(toolName)
+	if err != nil {
+		return nil, err
+	}
+	if serviceName == "system://"+api.CatalogTarget {
+		return nil, fmt.Errorf("cannot describe system catalog tools via describe_remote_tool")
+	}
+	n.preparePeerAddrs(ctx, pid)
+
+	session, cleanup, err := n.ConnectMCPSession(ctx, pid, serviceName, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	listRes, err := session.ListTools(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	if listRes == nil {
+		return nil, fmt.Errorf("list tools response was nil")
+	}
+
+	for _, tool := range listRes.Tools {
+		if tool == nil {
+			continue
+		}
+		if tool.Name == actualToolName {
+			return &remoteToolDescription{
+				PeerID:       pid.String(),
+				ToolName:     toolName,
+				Description:  tool.Description,
+				InputSchema:  tool.InputSchema,
+				OutputSchema: tool.OutputSchema,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("tool not found on peer")
+}
+
 // handleDescribeRemoteTool implements the describe_remote_tool client-facing tool.
 func (n *SamNode) handleDescribeRemoteTool(ctx context.Context, req *mcp.CallToolRequest, params DescribeRemoteToolParams) (*mcp.CallToolResult, any, error) {
 	if params.PeerID == "" {
@@ -606,52 +727,17 @@ func (n *SamNode) handleDescribeRemoteTool(ctx context.Context, req *mcp.CallToo
 		return nil, nil, fmt.Errorf("invalid peer_id: %w", err)
 	}
 
-	serviceName, actualToolName, err := api.SplitToolName(params.ToolName)
+	payload, err := n.fetchRemoteToolDescription(ctx, pid, params.ToolName)
 	if err != nil {
 		return nil, nil, err
 	}
-	if serviceName == "system://"+api.CatalogTarget {
-		return nil, nil, fmt.Errorf("cannot describe system catalog tools via describe_remote_tool")
-	}
-	n.preparePeerAddrs(ctx, pid)
-
-	session, cleanup, err := n.ConnectMCPSession(ctx, pid, serviceName, nil)
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer cleanup()
-
-	listRes, err := session.ListTools(ctx, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	if listRes == nil {
-		return nil, nil, fmt.Errorf("list tools response was nil")
-	}
-
-	for _, t := range listRes.Tools {
-		if t == nil {
-			continue
-		}
-		if t.Name == actualToolName {
-			payload := remoteToolDescription{
-				PeerID:       pid.String(),
-				ToolName:     params.ToolName,
-				Description:  t.Description,
-				InputSchema:  t.InputSchema,
-				OutputSchema: t.OutputSchema,
-			}
-			data, err := json.Marshal(payload)
-			if err != nil {
-				return nil, nil, err
-			}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: string(data)}},
-			}, nil, nil
-		}
-	}
-
-	return nil, nil, fmt.Errorf("tool not found on peer")
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(data)}},
+	}, nil, nil
 }
 
 // CheckConnectivityParams defines the parameters for the check_connectivity tool.

--- a/internal/node/mcp_handlers_test.go
+++ b/internal/node/mcp_handlers_test.go
@@ -516,6 +516,70 @@ func TestFetchRemoteToolCatalogue_AuthRejectedHidden(t *testing.T) {
 	}
 }
 
+func TestVerifyGossipToolRows_AuthenticatesEachServiceOnSamePeer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	allowedSrv := httptest.NewServer(newFakeMCPHandler(t, []*mcp.Tool{
+		{Name: "review_pr", Description: "authorized review", InputSchema: map[string]any{"type": "object"}},
+	}))
+	defer allowedSrv.Close()
+	deniedSrv := httptest.NewServer(newFakeMCPHandler(t, []*mcp.Tool{
+		{Name: "review_pr", Description: "unauthorized review", InputSchema: map[string]any{"type": "object"}},
+	}))
+	defer deniedSrv.Close()
+
+	nodeA, cleanupA := startBareNode(t, ctx)
+	defer cleanupA()
+	nodeB, cleanupB := startBareNode(t, ctx)
+	defer cleanupB()
+
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := buildAndSaveCustomBiscuit(nodeA, rootPriv, []string{"mcp://allowed-reviewer"}); err != nil {
+		t.Fatalf("buildAndSaveCustomBiscuit: %v", err)
+	}
+	nodeB.keysMu.Lock()
+	nodeB.trustedKeys = append(nodeB.trustedKeys, TrustedKey{Key: rootPub, ReceivedAt: time.Now()})
+	nodeB.keysMu.Unlock()
+	if err := nodeA.Host.Connect(ctx, peer.AddrInfo{ID: nodeB.Host.ID(), Addrs: nodeB.Host.Addrs()}); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, targetURL := range map[string]string{
+		"allowed-reviewer": allowedSrv.URL,
+		"denied-reviewer":  deniedSrv.URL,
+	} {
+		if err := nodeB.RegisterService(ctx, &api.RegisterServiceRequest{
+			Service: &api.ServiceInfo{Type: api.ServiceType_SERVICE_TYPE_MCP, Name: name},
+			Backend: &api.RegisterServiceRequest_TargetUrl{TargetUrl: targetURL},
+		}); err != nil {
+			t.Fatalf("RegisterService %s: %v", name, err)
+		}
+	}
+
+	peerID := nodeB.Host.ID().String()
+	rows := nodeA.verifyGossipToolRows(ctx, []remoteToolRow{
+		{PeerID: peerID, ToolName: "mcp://allowed-reviewer/review_pr", Labels: map[string]string{"region": "us"}},
+		{PeerID: peerID, ToolName: "mcp://denied-reviewer/review_pr", Labels: map[string]string{"region": "us"}},
+	})
+
+	if len(rows) != 1 {
+		t.Fatalf("expected one authorized row, got %d: %+v", len(rows), rows)
+	}
+	if rows[0].ToolName != "mcp://allowed-reviewer/review_pr" {
+		t.Fatalf("unexpected verified tool: %+v", rows[0])
+	}
+	if rows[0].Description != "authorized review" {
+		t.Errorf("Description = %q, want authorized review", rows[0].Description)
+	}
+	if rows[0].Labels["region"] != "us" {
+		t.Errorf("gossip routing labels were not preserved: %+v", rows[0].Labels)
+	}
+}
+
 func TestCallMCPTool_LabelEnforcement(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/internal/node/mcp_handlers_test.go
+++ b/internal/node/mcp_handlers_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
-
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -577,6 +579,82 @@ func TestVerifyGossipToolRows_AuthenticatesEachServiceOnSamePeer(t *testing.T) {
 	}
 	if rows[0].Labels["region"] != "us" {
 		t.Errorf("gossip routing labels were not preserved: %+v", rows[0].Labels)
+	}
+}
+
+func TestVerifyGossipToolRows_UsesIndependentRequestTimeouts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, publicKey, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerID, err := peer.IDFromPublicKey(publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidates := make([]remoteToolRow, 0, gossipVerificationMaxConcurrent+1)
+	for i := range gossipVerificationMaxConcurrent {
+		candidates = append(candidates, remoteToolRow{
+			PeerID:   peerID.String(),
+			ToolName: fmt.Sprintf("mcp://slow-%d/review_pr", i),
+		})
+	}
+	candidates = append(candidates, remoteToolRow{
+		PeerID:   peerID.String(),
+		ToolName: "mcp://fast/review_pr",
+	})
+
+	allSlowRequestsStarted := make(chan struct{})
+	releaseSlowRequests := make(chan struct{})
+	var slowRequestsStarted atomic.Int32
+	go func() {
+		select {
+		case <-allSlowRequestsStarted:
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case <-time.After(500 * time.Millisecond):
+			close(releaseSlowRequests)
+		case <-ctx.Done():
+		}
+	}()
+
+	var fastRequestBudget time.Duration
+	fetchDescription := func(ctx context.Context, pid peer.ID, toolName string) (*remoteToolDescription, error) {
+		if toolName == "mcp://fast/review_pr" {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return nil, errors.New("fast request has no deadline")
+			}
+			fastRequestBudget = time.Until(deadline)
+			return &remoteToolDescription{
+				PeerID:      pid.String(),
+				ToolName:    toolName,
+				Description: "verified after delayed candidates",
+			}, nil
+		}
+
+		if slowRequestsStarted.Add(1) == gossipVerificationMaxConcurrent {
+			close(allSlowRequestsStarted)
+		}
+		select {
+		case <-releaseSlowRequests:
+			return nil, errors.New("delayed candidate rejected")
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	rows := verifyGossipToolRowsWithFetcher(ctx, candidates, fetchDescription)
+	if len(rows) != 1 || rows[0].ToolName != "mcp://fast/review_pr" {
+		t.Fatalf("expected only the final candidate to verify, got %+v", rows)
+	}
+	if minimumBudget := gossipVerificationTimeout - 250*time.Millisecond; fastRequestBudget < minimumBudget {
+		t.Fatalf("final candidate inherited an exhausted timeout: got %v, want at least %v", fastRequestBudget, minimumBudget)
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses the exact-name discovery gap in #176.

The GossipSub fast path previously returned `ServiceAnnounce` rows directly. Announcements are useful routing hints, but they do not prove that the current caller is authorized to access the advertised MCP service.

This change:

- treats exact-name GossipSub rows as candidates rather than final results
- verifies each candidate through the existing authenticated MCP session
- confirms the exact tool is present in `tools/list` before returning it
- omits authorization, connection, malformed-peer, timeout, and missing-tool failures
- preserves candidate order and operator-declared routing labels
- falls back to the existing catalog discovery path when no gossip candidate verifies
- limits verification to eight workers and one shared five-second window
- reuses the same description helper as `describe_remote_tool`

There is no dependency, wire-format, or policy-model change.

## Regression coverage

The new test advertises two services on the same peer with the same tool name. The caller's Biscuit authorizes one service and denies the other. Only the authenticated service is returned, with its description populated from the verified MCP session.

## Validation

```text
go test -race ./internal/node -run TestVerifyGossipToolRows_AuthenticatesEachServiceOnSamePeer -count=1
go test ./internal/node -count=1
```

Both pass.

I also ran `go test ./... -count=1` in an unprivileged Go 1.25.7 container. The changed package and neighboring packages passed. The repository-wide command remained red on two environment-specific checks outside this patch: the Windows-copied embedded skill fixture retained CRLF, and `TestSamBoxNanoInitIntegration` could not call `unshare` in the unprivileged container.
