### PR TITLE
fix: do not advertise an MCP service whose backend is not one

### DIFF
--- a/internal/node/mcp_service.go
+++ b/internal/node/mcp_service.go
@@ -34,6 +34,41 @@ type MCPService struct {
 	toolsMu      sync.Mutex
 	cachedTools  []string
 	toolsExpires time.Time
+
+	probeMu      sync.Mutex
+	probeErr     error
+	probeExpires time.Time
+}
+
+// Probe reports whether the backend actually speaks MCP, by completing an
+// initialize against it.
+//
+// Deliberately weaker than Tools: a backend serving only resources or prompts
+// has no tools and is still a working MCP server, so an empty tool list is no
+// reason to withhold it. Failing to initialize is — that is a backend which is
+// down, or was never an MCP server to begin with.
+func (m *MCPService) Probe(ctx context.Context) error {
+	m.probeMu.Lock()
+	defer m.probeMu.Unlock()
+	if time.Now().Before(m.probeExpires) {
+		return m.probeErr
+	}
+	m.probeErr = m.dialBackend(ctx)
+	m.probeExpires = time.Now().Add(backendProbeTTL)
+	return m.probeErr
+}
+
+func (m *MCPService) dialBackend(ctx context.Context) error {
+	transport, err := m.backendTransport()
+	if err != nil {
+		return err
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "sam-node-probe", Version: "0.1.0"}, nil)
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		return fmt.Errorf("connect to backend of %q: %w", m.info.GetName(), err)
+	}
+	return session.Close()
 }
 
 // Init initializes the base service.

--- a/internal/node/mcp_service.go
+++ b/internal/node/mcp_service.go
@@ -48,12 +48,22 @@ type MCPService struct {
 // reason to withhold it. Failing to initialize is — that is a backend which is
 // down, or was never an MCP server to begin with.
 func (m *MCPService) Probe(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	m.probeMu.Lock()
 	defer m.probeMu.Unlock()
 	if time.Now().Before(m.probeExpires) {
 		return m.probeErr
 	}
-	m.probeErr = m.dialBackend(ctx)
+	err := m.dialBackend(ctx)
+	// A cancelled or expired context is a fact about the caller, not the
+	// backend. Caching it would withhold a merely slow service for the whole
+	// TTL -- the failure this gating is meant to avoid.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	m.probeErr = err
 	m.probeExpires = time.Now().Add(backendProbeTTL)
 	return m.probeErr
 }
@@ -68,7 +78,10 @@ func (m *MCPService) dialBackend(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("connect to backend of %q: %w", m.info.GetName(), err)
 	}
-	return session.Close()
+	// Connect completed the initialize, which is the whole question here; a
+	// failure to hang up afterwards does not unmake that.
+	_ = session.Close()
+	return nil
 }
 
 // Init initializes the base service.

--- a/internal/node/mcp_service.go
+++ b/internal/node/mcp_service.go
@@ -34,10 +34,6 @@ type MCPService struct {
 	toolsMu      sync.Mutex
 	cachedTools  []string
 	toolsExpires time.Time
-
-	probeMu      sync.Mutex
-	probeErr     error
-	probeExpires time.Time
 }
 
 // Probe reports whether the backend actually speaks MCP, by completing an
@@ -47,28 +43,12 @@ type MCPService struct {
 // has no tools and is still a working MCP server, so an empty tool list is no
 // reason to withhold it. Failing to initialize is — that is a backend which is
 // down, or was never an MCP server to begin with.
+//
+// The result is deliberately not cached. Callers are the registry's advertise
+// path, which asks once per service per reprovide, so the cost is negligible;
+// caching would make a backend that has just come up wait out the TTL, which
+// is the delay this gating exists to avoid.
 func (m *MCPService) Probe(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	m.probeMu.Lock()
-	defer m.probeMu.Unlock()
-	if time.Now().Before(m.probeExpires) {
-		return m.probeErr
-	}
-	err := m.dialBackend(ctx)
-	// A cancelled or expired context is a fact about the caller, not the
-	// backend. Caching it would withhold a merely slow service for the whole
-	// TTL -- the failure this gating is meant to avoid.
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return ctxErr
-	}
-	m.probeErr = err
-	m.probeExpires = time.Now().Add(backendProbeTTL)
-	return m.probeErr
-}
-
-func (m *MCPService) dialBackend(ctx context.Context) error {
 	transport, err := m.backendTransport()
 	if err != nil {
 		return err

--- a/internal/node/mcp_service_test.go
+++ b/internal/node/mcp_service_test.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/google/sam/api"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -61,14 +61,37 @@ func TestMCPService_ProbeRejectsNonMCPBackend(t *testing.T) {
 	if err := svc.Probe(context.Background()); err == nil {
 		t.Fatal("Probe accepted a backend that is not an MCP server")
 	}
-	if svc.probeExpires.IsZero() {
-		t.Error("a real negative result should be cached")
+}
+
+// Backends routinely start after the node does, so a failed probe must not be
+// sticky: the next one has to see the backend as it is now, not as it was.
+func TestMCPService_ProbeRecoversWhenBackendComesUp(t *testing.T) {
+	var up atomic.Bool
+	real := mcp.NewServer(&mcp.Implementation{Name: "late", Version: "0.0.1"}, nil)
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return real }, nil)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !up.Load() {
+			http.Error(w, "still starting", http.StatusServiceUnavailable)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	svc := newProbeService(ts.URL)
+	if err := svc.Probe(context.Background()); err == nil {
+		t.Fatal("Probe accepted a backend that was not serving yet")
+	}
+
+	up.Store(true)
+	if err := svc.Probe(context.Background()); err != nil {
+		t.Errorf("Probe still failing after the backend came up: %v", err)
 	}
 }
 
-// A cancelled context is a fact about the caller, not the backend. Caching it
-// would withhold a healthy service for the whole TTL.
-func TestMCPService_ProbeDoesNotCacheContextErrors(t *testing.T) {
+// A cancelled context is a fact about the caller, not the backend.
+func TestMCPService_ProbeFailsOnCancelledContext(t *testing.T) {
 	svc := newProbeService(newProbeBackend(t).URL)
 
 	cancelled, cancel := context.WithCancel(context.Background())
@@ -76,33 +99,8 @@ func TestMCPService_ProbeDoesNotCacheContextErrors(t *testing.T) {
 	if err := svc.Probe(cancelled); err == nil {
 		t.Fatal("Probe returned nil for a cancelled context")
 	}
-	if !svc.probeExpires.IsZero() {
-		t.Fatal("a context error was cached")
-	}
 
 	if err := svc.Probe(context.Background()); err != nil {
 		t.Errorf("Probe after a cancelled one: %v", err)
-	}
-}
-
-// The same, for a context that is alive on entry and expires mid-dial: this is
-// the slow backend the gating is explicitly meant not to punish.
-func TestMCPService_ProbeDoesNotCacheTimeouts(t *testing.T) {
-	// Answers, but never within the probe's deadline.
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(150 * time.Millisecond)
-		http.Error(w, "too slow", http.StatusServiceUnavailable)
-	}))
-	t.Cleanup(ts.Close)
-
-	svc := newProbeService(ts.URL)
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-
-	if err := svc.Probe(ctx); err == nil {
-		t.Fatal("Probe returned nil against a backend slower than the deadline")
-	}
-	if !svc.probeExpires.IsZero() {
-		t.Error("a timeout was cached: a slow backend would stay withheld for the whole TTL")
 	}
 }

--- a/internal/node/mcp_service_test.go
+++ b/internal/node/mcp_service_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/sam/api"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newProbeBackend serves a real MCP server that exposes no tools at all.
+func newProbeBackend(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "probe-backend", Version: "0.0.1"}, nil)
+	ts := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func newProbeService(url string) *MCPService {
+	return &MCPService{baseService: baseService{
+		info:    &api.ServiceInfo{Name: "probe-me", Type: api.ServiceType_SERVICE_TYPE_MCP},
+		backend: &api.RegisterServiceRequest_TargetUrl{TargetUrl: url},
+	}}
+}
+
+// Serving no tools is not a fault: a backend may serve only resources or
+// prompts and is still an MCP server, so it must stay advertisable.
+func TestMCPService_ProbeAcceptsToollessBackend(t *testing.T) {
+	svc := newProbeService(newProbeBackend(t).URL)
+	if err := svc.Probe(context.Background()); err != nil {
+		t.Errorf("Probe on a tool-less MCP backend: %v", err)
+	}
+}
+
+// The canary case: answers HTTP, is not an MCP server.
+func TestMCPService_ProbeRejectsNonMCPBackend(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(ts.Close)
+
+	svc := newProbeService(ts.URL)
+	if err := svc.Probe(context.Background()); err == nil {
+		t.Fatal("Probe accepted a backend that is not an MCP server")
+	}
+	if svc.probeExpires.IsZero() {
+		t.Error("a real negative result should be cached")
+	}
+}
+
+// A cancelled context is a fact about the caller, not the backend. Caching it
+// would withhold a healthy service for the whole TTL.
+func TestMCPService_ProbeDoesNotCacheContextErrors(t *testing.T) {
+	svc := newProbeService(newProbeBackend(t).URL)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := svc.Probe(cancelled); err == nil {
+		t.Fatal("Probe returned nil for a cancelled context")
+	}
+	if !svc.probeExpires.IsZero() {
+		t.Fatal("a context error was cached")
+	}
+
+	if err := svc.Probe(context.Background()); err != nil {
+		t.Errorf("Probe after a cancelled one: %v", err)
+	}
+}
+
+// The same, for a context that is alive on entry and expires mid-dial: this is
+// the slow backend the gating is explicitly meant not to punish.
+func TestMCPService_ProbeDoesNotCacheTimeouts(t *testing.T) {
+	// Answers, but never within the probe's deadline.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(150 * time.Millisecond)
+		http.Error(w, "too slow", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(ts.Close)
+
+	svc := newProbeService(ts.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	if err := svc.Probe(ctx); err == nil {
+		t.Fatal("Probe returned nil against a backend slower than the deadline")
+	}
+	if !svc.probeExpires.IsZero() {
+		t.Error("a timeout was cached: a slow backend would stay withheld for the whole TTL")
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -430,6 +430,7 @@ func (n *SamNode) Start(ctx context.Context) error {
 	n.DHT = kdht
 
 	n.services = NewServiceRegistry(n.DHT)
+	n.services.reprovideNow = n.triggerReprovide
 
 	var authenticated bool
 	var fatalAuthErr error
@@ -498,10 +499,7 @@ func (n *SamNode) Start(ctx context.Context) error {
 					// Debounce and trigger unified reprovide loop
 					go func() {
 						time.Sleep(2 * time.Second) // Small debounce
-						select {
-						case n.reprovideTrigger <- struct{}{}:
-						default:
-						}
+						n.triggerReprovide()
 					}()
 				}
 			}
@@ -544,6 +542,15 @@ func (n *SamNode) Start(ctx context.Context) error {
 	n.startPolicySyncLoop(ctx, n.config.PolicySyncInterval)
 
 	return nil
+}
+
+// triggerReprovide asks the reprovide loop to run a cycle now, dropping the
+// request when one is already pending.
+func (n *SamNode) triggerReprovide() {
+	select {
+	case n.reprovideTrigger <- struct{}{}:
+	default:
+	}
 }
 
 func (n *SamNode) startReprovideLoop(ctx context.Context, interval time.Duration) {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -90,6 +90,11 @@ const (
 
 	// Reprovide interval
 	ReprovideInterval = 5 * time.Minute
+
+	// reprovideRetryInterval is the first retry after a backend was withheld,
+	// doubling up to ReprovideInterval. Backends commonly start after the node
+	// does, and the full interval is far too long to wait for one of those.
+	reprovideRetryInterval = 5 * time.Second
 )
 
 var (
@@ -543,26 +548,36 @@ func (n *SamNode) Start(ctx context.Context) error {
 
 func (n *SamNode) startReprovideLoop(ctx context.Context, interval time.Duration) {
 	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
+		// Initial delay lets DHT bootstrap stabilize.
+		timer := time.NewTimer(5 * time.Second)
+		defer timer.Stop()
 
-		// Run an initial reprovide after a short delay to let DHT bootstrap stabilize
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(5 * time.Second):
-			n.services.ReprovideAll(ctx)
-		}
-
+		retry := reprovideRetryInterval
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
-				n.services.ReprovideAll(ctx)
+			case <-timer.C:
 			case <-n.reprovideTrigger:
-				n.services.ReprovideAll(ctx)
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
 			}
+
+			next := interval
+			if n.services.ReprovideAll(ctx) > 0 {
+				// A backend that is not answering yet is usually one that is
+				// still starting. Waiting the full interval would leave it
+				// undiscoverable for minutes after it came up.
+				next = retry
+				retry = min(retry*2, interval)
+			} else {
+				retry = reprovideRetryInterval
+			}
+			timer.Reset(next)
 		}
 	}()
 }

--- a/internal/node/service_registry.go
+++ b/internal/node/service_registry.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/sam/api"
@@ -188,10 +189,11 @@ func (r *ServiceRegistry) TeardownAll() {
 	}
 }
 
-// ReprovideAll re-provides all registered services to the DHT concurrently.
+// ReprovideAll re-provides all registered services to the DHT concurrently and
+// reports how many were withheld because their backend did not answer.
 // A service whose backend has stopped answering falls out of the DHT by not
 // being reprovided, and returns on a later tick once it answers again.
-func (r *ServiceRegistry) ReprovideAll(ctx context.Context) {
+func (r *ServiceRegistry) ReprovideAll(ctx context.Context) int {
 	r.mu.Lock()
 	toProvide := make([]Service, 0, len(r.services))
 	for _, svc := range r.services {
@@ -199,6 +201,7 @@ func (r *ServiceRegistry) ReprovideAll(ctx context.Context) {
 	}
 	r.mu.Unlock()
 
+	var withheld atomic.Int32
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 5)
 
@@ -220,7 +223,12 @@ Loop:
 
 			info := svc.Info()
 			if err := advertisable(ctx, svc); err != nil {
-				logger.Warnf("[ServiceRegistry] Withholding %s/%s from the DHT: backend did not answer: %v", info.Type, info.Name, err)
+				withheld.Add(1)
+				// On shutdown every service fails this way, and saying so
+				// would blame backends for the node stopping.
+				if ctx.Err() == nil {
+					logger.Warnf("[ServiceRegistry] Withholding %s/%s from the DHT: backend did not answer: %v", info.Type, info.Name, err)
+				}
 				return
 			}
 
@@ -237,4 +245,5 @@ Loop:
 		}()
 	}
 	wg.Wait()
+	return int(withheld.Load())
 }

--- a/internal/node/service_registry.go
+++ b/internal/node/service_registry.go
@@ -64,6 +64,11 @@ type ServiceRegistry struct {
 	mu       sync.RWMutex
 	services map[string]Service
 	dht      dhtProvider
+
+	// reprovideNow asks the node to run a reprovide cycle now, so a service
+	// registered after the loop last ran does not wait a whole interval to be
+	// advertised. Optional; nil outside a running node.
+	reprovideNow func()
 }
 
 func NewServiceRegistry(d dhtProvider) *ServiceRegistry {
@@ -122,6 +127,8 @@ func (r *ServiceRegistry) Register(ctx context.Context, svc Service) error {
 
 	if probeErr == nil {
 		logger.Infof("[ServiceRegistry] Registered %s/%s (name CID: %s, type CID: %s)", info.Type, info.Name, srvNameCID, srvTypeCID)
+	} else if r.reprovideNow != nil {
+		r.reprovideNow()
 	}
 	return nil
 }

--- a/internal/node/service_registry.go
+++ b/internal/node/service_registry.go
@@ -30,6 +30,34 @@ type dhtProvider interface {
 	Provide(ctx context.Context, c cid.Cid, broadcast bool) error
 }
 
+// backendProber is implemented by services that can be asked whether their
+// backend is really serving. Services that cannot be asked are advertised
+// unconditionally.
+type backendProber interface {
+	Probe(ctx context.Context) error
+}
+
+// dhtProbeTimeout bounds one backend probe before advertising.
+const dhtProbeTimeout = 2 * time.Second
+
+// advertisable reports whether a service is fit to be published to the DHT.
+//
+// Gossip already withholds announcements for a backend that does not answer,
+// but the DHT is the other half of discovery and had no such check, so a
+// backend that is not an MCP server at all stayed discoverable as one: it was
+// listed by discover_remote_services and only failed later, at initialize, in
+// the caller's face. Advertising is a claim the node makes on the backend's
+// behalf, so it is the node that should verify it.
+func advertisable(ctx context.Context, svc Service) error {
+	prober, ok := svc.(backendProber)
+	if !ok {
+		return nil
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, dhtProbeTimeout)
+	defer cancel()
+	return prober.Probe(probeCtx)
+}
+
 // ServiceRegistry is the type-agnostic owner of registered services.
 type ServiceRegistry struct {
 	mu       sync.RWMutex
@@ -47,6 +75,10 @@ func NewServiceRegistry(d dhtProvider) *ServiceRegistry {
 // Register initialises a service, advertises it on the DHT, and inserts it
 // into the map. Init runs before Provide so a failed handler-build never
 // briefly advertises an unservable name.
+//
+// A backend that does not answer is registered but not advertised, rather than
+// rejected: backends routinely start after the node does, and the reprovide
+// loop picks them up once they answer.
 func (r *ServiceRegistry) Register(ctx context.Context, svc Service) error {
 	info := svc.Info()
 	if info.Type == api.ServiceType_SERVICE_TYPE_UNSPECIFIED {
@@ -66,23 +98,30 @@ func (r *ServiceRegistry) Register(ctx context.Context, svc Service) error {
 		return err
 	}
 
-	nameCtx, nameCancel := context.WithTimeout(ctx, 5*time.Second)
-	defer nameCancel()
-	if err := r.dht.Provide(nameCtx, srvNameCID, true); err != nil {
-		logger.Warnf("[ServiceRegistry] DHT Provide (name) for %s: %v", info.Name, err)
-	}
+	probeErr := advertisable(ctx, svc)
+	if probeErr != nil {
+		logger.Warnf("[ServiceRegistry] Registered %s/%s but not advertising it: backend did not answer: %v", info.Type, info.Name, probeErr)
+	} else {
+		nameCtx, nameCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer nameCancel()
+		if err := r.dht.Provide(nameCtx, srvNameCID, true); err != nil {
+			logger.Warnf("[ServiceRegistry] DHT Provide (name) for %s: %v", info.Name, err)
+		}
 
-	typeCtx, typeCancel := context.WithTimeout(ctx, 5*time.Second)
-	defer typeCancel()
-	if err := r.dht.Provide(typeCtx, srvTypeCID, true); err != nil {
-		logger.Warnf("[ServiceRegistry] DHT Provide (type) for %s: %v", info.Name, err)
+		typeCtx, typeCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer typeCancel()
+		if err := r.dht.Provide(typeCtx, srvTypeCID, true); err != nil {
+			logger.Warnf("[ServiceRegistry] DHT Provide (type) for %s: %v", info.Name, err)
+		}
 	}
 
 	r.mu.Lock()
 	r.services[info.Name] = svc
 	r.mu.Unlock()
 
-	logger.Infof("[ServiceRegistry] Registered %s/%s (name CID: %s, type CID: %s)", info.Type, info.Name, srvNameCID, srvTypeCID)
+	if probeErr == nil {
+		logger.Infof("[ServiceRegistry] Registered %s/%s (name CID: %s, type CID: %s)", info.Type, info.Name, srvNameCID, srvTypeCID)
+	}
 	return nil
 }
 
@@ -150,11 +189,13 @@ func (r *ServiceRegistry) TeardownAll() {
 }
 
 // ReprovideAll re-provides all registered services to the DHT concurrently.
+// A service whose backend has stopped answering falls out of the DHT by not
+// being reprovided, and returns on a later tick once it answers again.
 func (r *ServiceRegistry) ReprovideAll(ctx context.Context) {
 	r.mu.Lock()
-	var toProvide []*api.ServiceInfo
+	toProvide := make([]Service, 0, len(r.services))
 	for _, svc := range r.services {
-		toProvide = append(toProvide, svc.Info())
+		toProvide = append(toProvide, svc)
 	}
 	r.mu.Unlock()
 
@@ -162,8 +203,8 @@ func (r *ServiceRegistry) ReprovideAll(ctx context.Context) {
 	sem := make(chan struct{}, 5)
 
 Loop:
-	for _, info := range toProvide {
-		info := info
+	for _, svc := range toProvide {
+		svc := svc
 		select {
 		case <-ctx.Done():
 			break Loop
@@ -176,6 +217,12 @@ Loop:
 				<-sem
 				wg.Done()
 			}()
+
+			info := svc.Info()
+			if err := advertisable(ctx, svc); err != nil {
+				logger.Warnf("[ServiceRegistry] Withholding %s/%s from the DHT: backend did not answer: %v", info.Type, info.Name, err)
+				return
+			}
 
 			if srvNameCID, err := serviceNameToCID(info.Type, info.Name); err == nil {
 				nameCtx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/internal/node/service_registry_test.go
+++ b/internal/node/service_registry_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -159,5 +160,90 @@ func TestServiceRegistry_TeardownAllContinuesOnError(t *testing.T) {
 	}
 	if len(r.List(api.ServiceType_SERVICE_TYPE_UNSPECIFIED)) != 0 {
 		t.Error("registry not empty after TeardownAll")
+	}
+}
+
+// probingService is a service whose backend can be asked whether it answers.
+type probingService struct {
+	*fakeService
+	mu         sync.Mutex
+	probeErr   error
+	probeCalls int
+}
+
+func (p *probingService) Probe(context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.probeCalls++
+	return p.probeErr
+}
+
+func (p *probingService) setProbeErr(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.probeErr = err
+}
+
+func newProbingSvc(name string, probeErr error) *probingService {
+	return &probingService{
+		fakeService: newFakeSvc(name, api.ServiceType_SERVICE_TYPE_MCP),
+		probeErr:    probeErr,
+	}
+}
+
+// A backend that is not an MCP server at all -- the canary that answers HTTP
+// but fails MCP initialize -- must not be advertised as one. It stays
+// registered so the reprovide loop can pick it up if it starts answering.
+func TestServiceRegistry_UnreachableBackendIsRegisteredButNotAdvertised(t *testing.T) {
+	dht := &fakeDHT{}
+	r := newServiceRegistryForTest(dht)
+
+	svc := newProbingSvc("dummy-http", errors.New(`calling "initialize": EOF`))
+	if err := r.Register(context.Background(), svc); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if len(dht.calls) != 0 {
+		t.Errorf("Provide called %d times for an unreachable backend, want 0", len(dht.calls))
+	}
+	if _, ok := r.Get("dummy-http"); !ok {
+		t.Error("service should stay registered so it can recover")
+	}
+}
+
+func TestServiceRegistry_ReprovideWithholdsUnreachableBackend(t *testing.T) {
+	dht := &fakeDHT{}
+	r := newServiceRegistryForTest(dht)
+
+	svc := newProbingSvc("demo", nil)
+	if err := r.Register(context.Background(), svc); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if len(dht.calls) != 2 {
+		t.Fatalf("Provide called %d times at registration, want 2", len(dht.calls))
+	}
+
+	svc.setProbeErr(errors.New("backend went away"))
+	r.ReprovideAll(context.Background())
+	if len(dht.calls) != 2 {
+		t.Errorf("Provide called %d times total, want 2: a backend that stopped answering must fall out of the DHT", len(dht.calls))
+	}
+}
+
+func TestServiceRegistry_ReprovideResumesWhenBackendRecovers(t *testing.T) {
+	dht := &fakeDHT{}
+	r := newServiceRegistryForTest(dht)
+
+	svc := newProbingSvc("demo", errors.New("not up yet"))
+	if err := r.Register(context.Background(), svc); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if len(dht.calls) != 0 {
+		t.Fatalf("Provide called %d times while the backend was down, want 0", len(dht.calls))
+	}
+
+	svc.setProbeErr(nil)
+	r.ReprovideAll(context.Background())
+	if len(dht.calls) != 2 {
+		t.Errorf("Provide called %d times after recovery, want 2 (name + type CID)", len(dht.calls))
 	}
 }

--- a/internal/node/service_registry_test.go
+++ b/internal/node/service_registry_test.go
@@ -223,7 +223,9 @@ func TestServiceRegistry_ReprovideWithholdsUnreachableBackend(t *testing.T) {
 	}
 
 	svc.setProbeErr(errors.New("backend went away"))
-	r.ReprovideAll(context.Background())
+	if withheld := r.ReprovideAll(context.Background()); withheld != 1 {
+		t.Errorf("ReprovideAll reported %d withheld, want 1: the retry cadence depends on it", withheld)
+	}
 	if len(dht.calls) != 2 {
 		t.Errorf("Provide called %d times total, want 2: a backend that stopped answering must fall out of the DHT", len(dht.calls))
 	}
@@ -242,7 +244,9 @@ func TestServiceRegistry_ReprovideResumesWhenBackendRecovers(t *testing.T) {
 	}
 
 	svc.setProbeErr(nil)
-	r.ReprovideAll(context.Background())
+	if withheld := r.ReprovideAll(context.Background()); withheld != 0 {
+		t.Errorf("ReprovideAll reported %d withheld after recovery, want 0", withheld)
+	}
 	if len(dht.calls) != 2 {
 		t.Errorf("Provide called %d times after recovery, want 2 (name + type CID)", len(dht.calls))
 	}

--- a/internal/node/service_registry_test.go
+++ b/internal/node/service_registry_test.go
@@ -210,6 +210,28 @@ func TestServiceRegistry_UnreachableBackendIsRegisteredButNotAdvertised(t *testi
 	}
 }
 
+// A service registered after the reprovide loop's last cycle would otherwise
+// wait a whole interval to be advertised, which is minutes.
+func TestServiceRegistry_WithheldRegistrationAsksForAReprovide(t *testing.T) {
+	r := newServiceRegistryForTest(&fakeDHT{})
+	var asked int
+	r.reprovideNow = func() { asked++ }
+
+	if err := r.Register(context.Background(), newProbingSvc("late", errors.New("not up yet"))); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if asked != 1 {
+		t.Errorf("reprovide requested %d times for a withheld service, want 1", asked)
+	}
+
+	if err := r.Register(context.Background(), newProbingSvc("healthy", nil)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if asked != 1 {
+		t.Errorf("reprovide requested %d times, want 1: an advertised service needs no retry", asked)
+	}
+}
+
 func TestServiceRegistry_ReprovideWithholdsUnreachableBackend(t *testing.T) {
 	dht := &fakeDHT{}
 	r := newServiceRegistryForTest(dht)

--- a/mobile/mobile_e2e.sh
+++ b/mobile/mobile_e2e.sh
@@ -209,6 +209,19 @@ class S(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "application/json")
             self.end_headers()
             self.wfile.write(json.dumps(res_data).encode("utf-8"))
+        elif req_id is not None:
+            # A request carrying an id must get a response; 202 with no body is
+            # only valid for notifications. Clients send unknown methods here
+            # (go-sdk probes "server/discover" before "initialize") and abort
+            # the connection if the reply is not JSON-RPC.
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": "Method not found"}
+            }).encode("utf-8"))
         else:
             self.send_response(202)
             self.end_headers()

--- a/mobile/mobile_e2e.sh
+++ b/mobile/mobile_e2e.sh
@@ -228,6 +228,15 @@ class S(BaseHTTPRequestHandler):
 HTTPServer(("0.0.0.0", 9091), S).serve_forever()
 '
 
+# The node probes a backend before advertising it, so the mock has to be
+# listening before the service below is registered.
+for _ in $(seq 1 30); do
+  curl -sf -o /dev/null -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
+    http://127.0.0.1:9091 && break
+  sleep 1
+done
+
 # Register a dummy MCP service on the host node pointing to the local mock server container (using container name)
 curl -s -X POST \
   -H "Content-Type: application/json" \

--- a/tests/e2e/services.bats
+++ b/tests/e2e/services.bats
@@ -20,6 +20,7 @@ start_calc_mcp() {
     --network-alias calc-mcp \
     "${CALC_MCP_IMAGE}" >/dev/null
   MESH_CONTAINERS+=("${name}")
+  mesh_wait_for_log "${name}" "Uvicorn running on" 20
 }
 
 setup() {

--- a/tests/integration/federation_test.go
+++ b/tests/integration/federation_test.go
@@ -239,17 +239,25 @@ roles:
 	waitForDHTReady(t, clientBin, apiPortA, "tokenA")
 	waitForDHTReady(t, clientBin, apiPortB, "tokenB")
 
-	// Start Mock Backend on Node A
-	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// A real MCP backend: the node probes it before advertising, so a stub
+	// returning a canned JSON-RPC body is deliberately never discoverable.
+	mcpServer := httptest.NewServer(newBoundaryMCPHandler(t))
+	t.Cleanup(func() { mcpServer.Close() })
+
+	// A backend that is not an MCP server. It is never advertised, but stays
+	// reachable when addressed explicitly, which is what the datapath below
+	// exercises: the proxy is a pipe and does not interpret what it carries.
+	rawServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"jsonrpc": "2.0", "id": 1, "result": {"success": true}}`))
 	}))
-	t.Cleanup(func() { mcpServer.Close() })
+	t.Cleanup(func() { rawServer.Close() })
 
 	// Publish a service on Node A
 	t.Log("Publishing tool on Node A...")
 	registerService(t, fmt.Sprintf("127.0.0.1:%d", apiPortA), "tokenA", "federated-tool", mcpServer.URL)
+	registerService(t, fmt.Sprintf("127.0.0.1:%d", apiPortA), "tokenA", "raw-pipe", rawServer.URL)
 	time.Sleep(2 * time.Second)
 
 	// Search for the service from Node B
@@ -301,8 +309,8 @@ roles:
 	}
 	peerIDA_node := matches[1]
 
-	// The proxy path on Node B is /sam/<peerID>/mcp/federated-tool
-	proxyURL := fmt.Sprintf("http://127.0.0.1:%d/sam/%s/mcp/federated-tool", apiPortB, peerIDA_node)
+	// The proxy path on Node B is /sam/<peerID>/mcp/raw-pipe
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d/sam/%s/mcp/raw-pipe", apiPortB, peerIDA_node)
 	req, _ := http.NewRequest("POST", proxyURL, bytes.NewBuffer([]byte(`{"jsonrpc": "2.0", "id": 1, "method": "test"}`)))
 	req.Header.Set(api.HeaderSamAuthentication, "Bearer tokenB")
 

--- a/tests/integration/service_discovery_test.go
+++ b/tests/integration/service_discovery_test.go
@@ -95,9 +95,9 @@ func TestServiceDiscovery(t *testing.T) {
 		t.Fatalf("DHT not ready on Node A (size 0)")
 	}
 
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "Not found", http.StatusNotFound)
-	}))
+	// A real MCP backend: the node probes it before advertising, so a stub that
+	// cannot complete an initialize is deliberately never discoverable.
+	mockServer := httptest.NewServer(newBoundaryMCPHandler(t))
 	defer mockServer.Close()
 
 	// Agent A registers a service
@@ -198,9 +198,9 @@ func TestServiceDiscoveryStreaming(t *testing.T) {
 		t.Fatalf("DHT not ready on Node A")
 	}
 
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "Not found", http.StatusNotFound)
-	}))
+	// A real MCP backend: the node probes it before advertising, so a stub that
+	// cannot complete an initialize is deliberately never discoverable.
+	mockServer := httptest.NewServer(newBoundaryMCPHandler(t))
 	defer mockServer.Close()
 
 	// Agent A registers a service


### PR DESCRIPTION
The canary named dummy-http is k8s agnhost: it answers HTTP and is registered as type mcp, but it is not an MCP server and never was. It was advertised anyway, so discover_remote_services listed it as healthy and every caller found out otherwise later, at initialize, three peers at a time.

The node already knew. Gossip probes each backend and withholds the announcement when it does not answer, but the DHT half of discovery had no such check and provided the name and type CIDs unconditionally, at registration and again every five minutes. One channel asked, the other asserted. Advertising is a claim the node makes on a backend's behalf, so the node is what should verify it.

Probe completes an MCP initialize against the backend, cached for the existing 30s TTL, and DHT publication is gated on it. Deliberately weaker than the tool listing gossip uses: a backend serving only resources or prompts has no tools and is still a working MCP server, so an empty tool list must not hide it. A backend that does not answer stays registered and simply is not advertised, so one that starts late returns on a later reprovide rather than being hidden until restart -- and one that dies falls back out.

Three integration tests failed, all of them asserting the old behaviour with fixtures that were the bug: two registered a backend answering 404 to everything, which is dummy-http exactly, and asserted it was discoverable. They get real MCP backends now. The federation test then failed further along, on a raw POST expecting a stub's canned reply -- that assertion is about byte forwarding, not MCP, so it now has its own non-MCP backend and states the distinction the change draws: a backend that is not an MCP server stays reachable when addressed explicitly, and is not advertised.