### PR TITLE
SSE-safe HTTP timeouts in SamClient, self peer_id in get_mesh_info

### DIFF
--- a/internal/node/mcp_handlers.go
+++ b/internal/node/mcp_handlers.go
@@ -218,6 +218,7 @@ func (n *SamNode) handleGetMeshInfo(ctx context.Context, req *mcp.CallToolReques
 	dhtSize := n.DHT.RoutingTable().Size()
 
 	resData := map[string]any{
+		"peer_id":         n.Host.ID().String(),
 		"connected_peers": connectedPeers,
 		"dht_size":        dhtSize,
 		"router_peer_id":  n.RouterPeerID.String(),

--- a/sam-mcp-python/src/sam_mcp/client.py
+++ b/sam-mcp-python/src/sam_mcp/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from typing import Any, Dict, List, Optional
+import httpx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 
@@ -19,12 +20,16 @@ class SamClient:
 
     async def connect(self):
         """Connects to the SAM node via Streamable HTTP."""
-        import httpx
         headers = {"Accept": "application/json, text/event-stream"}
         if self.token:
             headers["X-Sam-Authentication"] = f"Bearer {self.token}"
-        
-        self._http_client = httpx.AsyncClient(headers=headers)
+
+        self._http_client = httpx.AsyncClient(
+            headers=headers,
+            follow_redirects=True,
+            # The SDK's SSE-friendly defaults; httpx's default 5s read timeout drops the stream.
+            timeout=httpx.Timeout(30.0, read=300.0),
+        )
         try:
             self._sh_cm = streamable_http_client(self.server_url, http_client=self._http_client)
             res = await self._sh_cm.__aenter__()


### PR DESCRIPTION
The two changes from #314 requested for immediate merge (https://github.com/google/sam/pull/314#issuecomment-5417351387):

- sam_mcp/client.py: use the MCP SDK's create_mcp_http_client so the SSE stream isn't dropped by httpx's default 5s read timeout.
- get_mesh_info now returns the node's own peer_id.