### PR TITLE
More CI flake fixes

### DIFF
--- a/api/datalog_test.go
+++ b/api/datalog_test.go
@@ -333,7 +333,7 @@ func TestControlPlaneStaticTimeCheck(t *testing.T) {
 			}})
 
 			tok, _ := builder.Build()
-			authorizer, _ := tok.Authorizer(pub)
+			authorizer, _ := tok.Authorizer(pub, biscuit.WithWorldOptions(datalog.WithMaxDuration(5*time.Second)))
 
 			authorizer.AddFact(biscuit.Fact{Predicate: biscuit.Predicate{
 				Name: FactTime,

--- a/internal/controlplane/biscuit_ttl_test.go
+++ b/internal/controlplane/biscuit_ttl_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/biscuit-auth/biscuit-go/v2/parser"
 	"github.com/google/sam/api"
+	"github.com/google/sam/internal/identity"
 	"github.com/google/sam/internal/storage"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -35,14 +36,14 @@ import (
 )
 
 // biscuitExpiration reads the expiration() authority fact out of a minted token.
-func biscuitExpiration(t *testing.T, tokenBytes []byte, cpPubKey ed25519.PublicKey) time.Time {
+func biscuitExpiration(t *testing.T, tokenBytes []byte, cpPubKey ed25519.PublicKey, timeout time.Duration) time.Time {
 	t.Helper()
 
 	b, err := biscuit.Unmarshal(tokenBytes)
 	if err != nil {
 		t.Fatalf("malformed biscuit: %v", err)
 	}
-	authorizer, err := b.Authorizer(cpPubKey)
+	authorizer, err := b.Authorizer(cpPubKey, identity.AuthorizerOptions(timeout)...)
 	if err != nil {
 		t.Fatalf("authorizer: %v", err)
 	}
@@ -185,6 +186,7 @@ func TestBiscuitExpiryIsCappedByItsVoucher(t *testing.T) {
 		t.Helper()
 		srv, store, cpURL := setupTestServer(t, issuer, func(o *Options) {
 			o.BiscuitTTL = ttl
+			o.BiscuitTimeout = 5 * time.Second
 		})
 		t.Cleanup(func() {
 			_ = srv.Close()
@@ -199,29 +201,29 @@ func TestBiscuitExpiryIsCappedByItsVoucher(t *testing.T) {
 	}
 
 	t.Run("register clamps to the OIDC token when it expires first", func(t *testing.T) {
-		_, _, cpURL := start(t, 24*time.Hour)
+		srv, _, cpURL := start(t, 24*time.Hour)
 		oidcExpiry := time.Now().Add(10 * time.Minute)
 
 		_, _, resp := registerNode(t, cpURL, newJWT(10*time.Minute))
 		cpPubKey := ed25519.PublicKey(resp.ControlPlanePublicKey)
 
-		assertNear(t, "biscuit expiration()", biscuitExpiration(t, resp.BiscuitToken, cpPubKey), oidcExpiry)
+		assertNear(t, "biscuit expiration()", biscuitExpiration(t, resp.BiscuitToken, cpPubKey, srv.config.BiscuitTimeout), oidcExpiry)
 		assertNear(t, "EnrollResponse.Expiration", time.Unix(resp.Expiration, 0), oidcExpiry)
 	})
 
 	t.Run("register uses the configured TTL when it expires first", func(t *testing.T) {
-		_, _, cpURL := start(t, 5*time.Minute)
+		srv, _, cpURL := start(t, 5*time.Minute)
 		want := time.Now().Add(5 * time.Minute)
 
 		_, _, resp := registerNode(t, cpURL, newJWT(time.Hour))
 		cpPubKey := ed25519.PublicKey(resp.ControlPlanePublicKey)
 
-		assertNear(t, "biscuit expiration()", biscuitExpiration(t, resp.BiscuitToken, cpPubKey), want)
+		assertNear(t, "biscuit expiration()", biscuitExpiration(t, resp.BiscuitToken, cpPubKey, srv.config.BiscuitTimeout), want)
 		assertNear(t, "EnrollResponse.Expiration", time.Unix(resp.Expiration, 0), want)
 	})
 
 	t.Run("refresh clamps to the end of the OIDC session", func(t *testing.T) {
-		_, store, cpURL := start(t, 24*time.Hour)
+		srv, store, cpURL := start(t, 24*time.Hour)
 		priv, peerID, resp := registerNode(t, cpURL, newJWT(time.Hour))
 		cpPubKey := ed25519.PublicKey(resp.ControlPlanePublicKey)
 
@@ -237,12 +239,12 @@ func TestBiscuitExpiryIsCappedByItsVoucher(t *testing.T) {
 		}
 
 		refreshed := refreshNode(t, cpURL, priv, resp.BiscuitToken)
-		assertNear(t, "refreshed biscuit expiration()", biscuitExpiration(t, refreshed.BiscuitToken, cpPubKey), sessionEnd)
+		assertNear(t, "refreshed biscuit expiration()", biscuitExpiration(t, refreshed.BiscuitToken, cpPubKey, srv.config.BiscuitTimeout), sessionEnd)
 		assertNear(t, "TokenRefreshResponse.ExpiresAt", time.Unix(refreshed.ExpiresAt, 0), sessionEnd)
 	})
 
 	t.Run("refresh uses the configured TTL when the session never expires", func(t *testing.T) {
-		_, store, cpURL := start(t, 30*time.Minute)
+		srv, store, cpURL := start(t, 30*time.Minute)
 		priv, peerID, resp := registerNode(t, cpURL, newJWT(time.Hour))
 		cpPubKey := ed25519.PublicKey(resp.ControlPlanePublicKey)
 
@@ -258,6 +260,6 @@ func TestBiscuitExpiryIsCappedByItsVoucher(t *testing.T) {
 
 		want := time.Now().Add(30 * time.Minute)
 		refreshed := refreshNode(t, cpURL, priv, resp.BiscuitToken)
-		assertNear(t, "refreshed biscuit expiration()", biscuitExpiration(t, refreshed.BiscuitToken, cpPubKey), want)
+		assertNear(t, "refreshed biscuit expiration()", biscuitExpiration(t, refreshed.BiscuitToken, cpPubKey, srv.config.BiscuitTimeout), want)
 	})
 }

--- a/internal/identity/attenuation_test.go
+++ b/internal/identity/attenuation_test.go
@@ -77,7 +77,7 @@ func TestAttenuationBlockFactsAreInvisibleToTheAuthorizer(t *testing.T) {
 		t.Fatalf("appended block count = %d, want 1", attenuated.BlockCount())
 	}
 
-	authorizer, err := attenuated.Authorizer(pub)
+	authorizer, err := attenuated.Authorizer(pub, AuthorizerOptions(5*time.Second)...)
 	if err != nil {
 		t.Fatalf("Authorizer: %v", err)
 	}

--- a/internal/identity/biscuit_test.go
+++ b/internal/identity/biscuit_test.go
@@ -360,7 +360,7 @@ func TestMintBiscuitToken_VariousClaimsTypes(t *testing.T) {
 				t.Fatalf("Unmarshal biscuit failed: %v", err)
 			}
 
-			authorizer, err := b.Authorizer(pub)
+			authorizer, err := b.Authorizer(pub, AuthorizerOptions(5*time.Second)...)
 			if err != nil {
 				t.Fatalf("Authorizer failed: %v", err)
 			}
@@ -439,7 +439,7 @@ func TestMintBiscuitToken_WithPolicyRoles(t *testing.T) {
 			t.Fatalf("Unmarshal biscuit failed: %v", err)
 		}
 
-		authorizer, err := b.Authorizer(pub)
+		authorizer, err := b.Authorizer(pub, AuthorizerOptions(5*time.Second)...)
 		if err != nil {
 			t.Fatalf("Authorizer failed: %v", err)
 		}
@@ -468,7 +468,7 @@ func TestMintBiscuitToken_WithPolicyRoles(t *testing.T) {
 			t.Fatalf("Unmarshal biscuit failed: %v", err)
 		}
 
-		authorizer, err := b.Authorizer(pub)
+		authorizer, err := b.Authorizer(pub, AuthorizerOptions(5*time.Second)...)
 		if err != nil {
 			t.Fatalf("Authorizer failed: %v", err)
 		}
@@ -504,7 +504,7 @@ func TestMintBiscuitToken_LabelFacts(t *testing.T) {
 
 	// Every declared label is present as its own fact.
 	for k, v := range labels {
-		authorizer, err := b.Authorizer(pub)
+		authorizer, err := b.Authorizer(pub, AuthorizerOptions(5*time.Second)...)
 		if err != nil {
 			t.Fatalf("Authorizer failed: %v", err)
 		}
@@ -526,7 +526,7 @@ func TestMintBiscuitToken_LabelFacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unmarshal biscuit failed: %v", err)
 	}
-	authorizer, err := b2.Authorizer(pub)
+	authorizer, err := b2.Authorizer(pub, AuthorizerOptions(5*time.Second)...)
 	if err != nil {
 		t.Fatalf("Authorizer failed: %v", err)
 	}

--- a/tests/integration/minimal_helpers_test.go
+++ b/tests/integration/minimal_helpers_test.go
@@ -617,8 +617,9 @@ func waitForControlPlane(t *testing.T, port int) {
 
 	var lastErr error
 	var lastStatus int
+	client := &http.Client{Timeout: 2 * time.Second}
 	for {
-		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/info", port))
+		resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/info", port))
 		if err == nil {
 			lastStatus = resp.StatusCode
 			_ = resp.Body.Close()

--- a/tests/integration/minimal_helpers_test.go
+++ b/tests/integration/minimal_helpers_test.go
@@ -615,18 +615,28 @@ func waitForControlPlane(t *testing.T, port int) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	var lastErr error
+	var lastStatus int
 	for {
 		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/info", port))
 		if err == nil {
+			lastStatus = resp.StatusCode
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
 				return
 			}
+			lastErr = nil
+		} else {
+			lastErr = err
+			lastStatus = 0
 		}
 
 		select {
 		case <-ctx.Done():
-			t.Fatalf("timed out waiting for control plane: %v", err)
+			if lastErr != nil {
+				t.Fatalf("timed out waiting for control plane /info: last error: %v", lastErr)
+			}
+			t.Fatalf("timed out waiting for control plane /info: last HTTP status %d", lastStatus)
 		case <-time.After(100 * time.Millisecond):
 		}
 	}

--- a/tests/integration/multimaster_test.go
+++ b/tests/integration/multimaster_test.go
@@ -147,7 +147,7 @@ roles: []
 	defer func() { _ = cmdRouterA.Process.Kill(); _ = cmdRouterA.Wait() }()
 
 	// Wait for Router A to renew lease and register in CP A
-	time.Sleep(3 * time.Second)
+	waitForActiveRouters(t, portA, 1, 5*time.Second)
 
 	// 5. Start Control Plane B (sharing CP A's keys)
 	cmdCP_B := exec.Command(cpBin,
@@ -185,7 +185,10 @@ roles: []
 	defer func() { _ = cmdRouterB.Process.Kill(); _ = cmdRouterB.Wait() }()
 
 	// Wait for Router B to renew lease and register in CP B
-	time.Sleep(3 * time.Second)
+	peerInfoListB := waitForActiveRouters(t, portB, 1, 5*time.Second)
+	if len(peerInfoListB) != 1 {
+		t.Fatalf("expected 1 router registered on CP B, got %d", len(peerInfoListB))
+	}
 
 	// 6. Fetch router peer IDs
 	peerInfoListA := fetchActiveRouters(t, portA)
@@ -193,11 +196,6 @@ roles: []
 		t.Fatalf("expected 1 router registered on CP A, got %d", len(peerInfoListA))
 	}
 	peerIDA := peerInfoListA[0]
-
-	peerInfoListB := fetchActiveRouters(t, portB)
-	if len(peerInfoListB) != 1 {
-		t.Fatalf("expected 1 router registered on CP B, got %d", len(peerInfoListB))
-	}
 	peerIDB := peerInfoListB[0]
 
 	// ASSERT: Router A and Router B have unique Peer IDs

--- a/tests/integration/policy_grants_test.go
+++ b/tests/integration/policy_grants_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/biscuit-auth/biscuit-go/v2/parser"
 	"github.com/google/sam/api"
+	"github.com/google/sam/internal/identity"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"google.golang.org/protobuf/proto"
@@ -271,7 +272,7 @@ func authorizeToken(t *testing.T, tokenBytes []byte, pub ed25519.PublicKey) bisc
 	if err != nil {
 		t.Fatalf("unmarshal biscuit: %v", err)
 	}
-	authorizer, err := b.Authorizer(pub)
+	authorizer, err := b.Authorizer(pub, identity.AuthorizerOptions(5*time.Second)...)
 	if err != nil {
 		t.Fatalf("authorizer: %v", err)
 	}


### PR DESCRIPTION
- biscuit evaluation on ci takes longer because the race detector is enabled so override the timeout like we do in other testing
- plain sleeps are wrong, this is tech debt we need to fix by implementing active polling and not relying on waiting async expecting thigs to happen the way we want