### PR TITLE
fix(node): initialize BiscuitTimeout in NewSamNode

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -271,6 +271,7 @@ func NewSamNode(cfg Options) (*SamNode, error) {
 		AllowLoopback:        cfg.AllowLoopback,
 		authSuccess:          make(chan struct{}),
 		reprovideTrigger:     make(chan struct{}, 1),
+		BiscuitTimeout:       cfg.BiscuitTimeout,
 		logger:               golog.Logger("sam-node"),
 	}
 

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/google/sam/api"
+	"github.com/google/sam/internal/identity"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -286,6 +287,39 @@ func TestNewSamNode_Validation(t *testing.T) {
 		})
 		if err == nil || err.Error() != "store is required" {
 			t.Errorf("expected 'store is required' error, got: %v", err)
+		}
+	})
+}
+
+func TestNewSamNode_BiscuitTimeout(t *testing.T) {
+	priv, _, _ := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	store, _ := NewStore(t.TempDir())
+	defer func() { _ = store.Close() }()
+
+	t.Run("defaults when unset", func(t *testing.T) {
+		node, err := NewSamNode(Options{
+			PrivKey: priv,
+			Store:   store,
+		})
+		if err != nil {
+			t.Fatalf("NewSamNode: %v", err)
+		}
+		if node.BiscuitTimeout != identity.DefaultAuthorizerTimeout {
+			t.Errorf("BiscuitTimeout = %v, want default %v", node.BiscuitTimeout, identity.DefaultAuthorizerTimeout)
+		}
+	})
+
+	t.Run("explicit value respected", func(t *testing.T) {
+		node, err := NewSamNode(Options{
+			PrivKey:        priv,
+			Store:          store,
+			BiscuitTimeout: 10 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("NewSamNode: %v", err)
+		}
+		if node.BiscuitTimeout != 10*time.Second {
+			t.Errorf("BiscuitTimeout = %v, want 10s", node.BiscuitTimeout)
 		}
 	})
 }

--- a/internal/node/options.go
+++ b/internal/node/options.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/sam/api"
+	"github.com/google/sam/internal/identity"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/multiformats/go-multiaddr"
 )
@@ -58,6 +59,8 @@ type Options struct {
 	AutoRelayBackoff     time.Duration
 	// RouterConnectTimeout bounds each router address's dial (connect + stream open).
 	RouterConnectTimeout time.Duration
+	// BiscuitTimeout bounds Datalog evaluation when verifying biscuit tokens.
+	BiscuitTimeout time.Duration
 	// DHT Options
 	DHTProviderAddrTTL   time.Duration
 	DHTMaxRecordAge      time.Duration
@@ -100,6 +103,9 @@ func (o *Options) Default() {
 	}
 	if o.RouterConnectTimeout == 0 {
 		o.RouterConnectTimeout = DefaultRouterConnectTimeout
+	}
+	if o.BiscuitTimeout <= 0 {
+		o.BiscuitTimeout = identity.DefaultAuthorizerTimeout
 	}
 	if o.DHTLookupLimit <= 0 {
 		o.DHTLookupLimit = 20


### PR DESCRIPTION
SamNode.BiscuitTimeout was never set on the production path — only tests assigned it — so every biscuit verification on the node (enroll, middleware, labels gate, identity evidence, relay auth) silently ran on the `identity.DefaultAuthorizerTimeout` fallback, and there was no way to configure the node's Datalog evaluation budget.

This surfaced while reviewing #334 (see the non-blocking note there); it predates that PR, so fixing it separately to keep #334 focused.

Changes:
- Add `Options.BiscuitTimeout` to `node.Options`.
- Default it to `identity.DefaultAuthorizerTimeout` in `Options.Default()`, mirroring `internal/router/config.go`.
- Wire it through `NewSamNode`.
- Unit test covering the default and an explicit value.

No behavior change for callers that leave it unset (the fallback was already 1s).