### PR TITLE
fix(router): support key rotation in mutual auth handshake

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -940,13 +940,13 @@ func (r *Router) performMutualAuth(s network.Stream) error {
 	}
 
 	// Verify remote biscuit
-	b, err := identity.VerifyBiscuit(resp.Biscuit, remotePeer, trustedKeys, r.config.BiscuitTimeout)
+	b, verifyingKey, err := identity.VerifyBiscuitAndGetKey(resp.Biscuit, remotePeer, trustedKeys, r.config.BiscuitTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to verify peer router biscuit: %w", err)
 	}
 
 	// Enforce required role inside the biscuit
-	authorizer, err := b.Authorizer(trustedKeys[0], identity.AuthorizerOptions(r.config.BiscuitTimeout)...)
+	authorizer, err := b.Authorizer(verifyingKey, identity.AuthorizerOptions(r.config.BiscuitTimeout)...)
 	if err != nil {
 		return fmt.Errorf("authorizer instantiation failed: %w", err)
 	}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/sam/internal/storage"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-msgio"
 	"github.com/multiformats/go-multiaddr"
@@ -800,5 +801,74 @@ func TestRouterDefaultBiscuitTimeout(t *testing.T) {
 	opts.Default()
 	if opts.BiscuitTimeout != identity.DefaultAuthorizerTimeout {
 		t.Fatalf("expected default biscuit timeout %v, got %v", identity.DefaultAuthorizerTimeout, opts.BiscuitTimeout)
+	}
+}
+
+// TestPerformMutualAuthAcceptsRotatedKey covers the key rotation window: the
+// remote biscuit is signed by the second trusted key, so the role authorizer
+// must be built from the key that actually verified, not trustedKeys[0].
+func TestPerformMutualAuthAcceptsRotatedKey(t *testing.T) {
+	oldPub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newPub, newPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverHost, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = serverHost.Close() }()
+
+	clientHost, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = clientHost.Close() }()
+
+	serverBiscuit, err := identity.MintBootstrapBiscuitToken(newPriv, serverHost.ID(), api.RoleRouter, time.Now().Add(time.Hour), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverHost.SetStreamHandler(api.AuthProtocolID, func(s network.Stream) {
+		defer func() { _ = s.Close() }()
+		reader := msgio.NewVarintReaderSize(s, 1024*64)
+		msg, err := reader.ReadMsg()
+		if err != nil {
+			return
+		}
+		reader.ReleaseMsg(msg)
+		respBytes, _ := proto.Marshal(&api.AuthResponse{Success: true, Biscuit: serverBiscuit})
+		_ = msgio.NewVarintWriter(s).WriteMsg(respBytes)
+	})
+
+	r := &Router{
+		Host:              clientHost,
+		biscuitToken:      []byte("client-biscuit"),
+		trustedPublicKeys: []ed25519.PublicKey{oldPub, newPub},
+		config: Options{
+			BiscuitTimeout: time.Second,
+			RequiredRole:   api.RoleRouter,
+		},
+	}
+
+	if err := clientHost.Connect(context.Background(), peer.AddrInfo{ID: serverHost.ID(), Addrs: serverHost.Addrs()}); err != nil {
+		t.Fatal(err)
+	}
+	s, err := clientHost.NewStream(context.Background(), serverHost.ID(), api.AuthProtocolID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if err := r.performMutualAuth(s); err != nil {
+		t.Fatalf("mutual auth failed with biscuit signed by rotated key: %v", err)
+	}
+	if _, ok := r.authenticatedPeers.Load(serverHost.ID()); !ok {
+		t.Fatal("peer not recorded as authenticated")
 	}
 }


### PR DESCRIPTION
While reviewing #334 we swept for other instances of the same bug class and found one in the router: `performMutualAuth` verifies the remote biscuit against **all** trusted control plane keys, but then builds the role authorizer from `trustedKeys[0]`. A biscuit signed by a rotated key passes verification and then fails authorization (`biscuit: invalid signature`), breaking router-to-router mutual auth for the entire rotation window.

This is the router-side twin of the node-side issue flagged in the #334 review; #334 doesn't touch this file.

Changes:
- Use `identity.VerifyBiscuitAndGetKey` and build the authorizer from the key that actually verified.
- Unit test `TestPerformMutualAuthAcceptsRotatedKey`: remote biscuit signed by the second trusted key must authenticate. Verified red against the old code (fails with `authorizer instantiation failed: biscuit: invalid signature`) and green with the fix.