### PR TITLE
fix(node): make the trusted key lifecycle survive rotation, restarts and offline windows

### DIFF
--- a/internal/node/controlplane.go
+++ b/internal/node/controlplane.go
@@ -15,7 +15,9 @@
 package node
 
 import (
+	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -67,6 +69,69 @@ func FetchControlPlaneInfo(ctx context.Context, controlPlaneURL string) (*api.Co
 	return &info, nil
 }
 
+// FetchControlPlaneKeys retrieves the full set of currently valid control
+// plane public keys from the /keys endpoint — the same catch-up path routers
+// use. Enrollment only hands out the newest key, so this is how a node
+// learns keys still in their rotation grace period, or rotations it missed
+// while offline.
+func FetchControlPlaneKeys(ctx context.Context, controlPlaneURL string) ([]ed25519.PublicKey, error) {
+	if !strings.HasPrefix(controlPlaneURL, "http://") && !strings.HasPrefix(controlPlaneURL, "https://") {
+		controlPlaneURL = "https://" + controlPlaneURL
+	}
+	controlPlaneURL = strings.TrimSuffix(controlPlaneURL, "/")
+
+	req, err := http.NewRequestWithContext(ctx, "GET", controlPlaneURL+"/keys", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("control plane returned status %s: %s", resp.Status, string(body))
+	}
+
+	var keysResp api.KeysResponse
+	if err := proto.Unmarshal(body, &keysResp); err != nil {
+		return nil, fmt.Errorf("failed to decode /keys response: %w", err)
+	}
+
+	var keys []ed25519.PublicKey
+	for _, kb := range keysResp.PublicKeys {
+		if len(kb) == ed25519.PublicKeySize {
+			keys = append(keys, ed25519.PublicKey(kb))
+		}
+	}
+	return keys, nil
+}
+
+// mergeTrustedKeys replaces the stored trust set with the authoritative set
+// from /keys, preserving ReceivedAt for keys already known so local grace
+// pruning keeps working across syncs.
+func mergeTrustedKeys(existing []TrustedKey, fetched []ed25519.PublicKey, now time.Time) []TrustedKey {
+	merged := make([]TrustedKey, 0, len(fetched))
+	for _, key := range fetched {
+		tk := TrustedKey{Key: key, ReceivedAt: now}
+		for _, old := range existing {
+			if bytes.Equal(old.Key, key) {
+				tk.ReceivedAt = old.ReceivedAt
+				break
+			}
+		}
+		merged = append(merged, tk)
+	}
+	return merged
+}
+
 // SyncMeshConfig loads the mesh configuration from the store, attempts to refresh it
 // via HTTP from the control plane, and updates the store if successful.
 // It returns the control plane public key and the latest multiaddresses.
@@ -116,6 +181,20 @@ func SyncMeshConfig(ctx context.Context, s *Store) ([]byte, []multiaddr.Multiadd
 						logger.Errorf("Failed to save updated mesh config to store: %v", saveErr)
 					}
 				}
+			}
+		}
+
+		// Catch up on the valid key set: an empty result would wipe the trust
+		// set, so it is ignored like any fetch failure.
+		if keys, keysErr := FetchControlPlaneKeys(ctx, controlPlaneURL); keysErr != nil {
+			logger.Warnf("Failed to fetch control plane keys via HTTP (using cached): %v", keysErr)
+		} else if len(keys) > 0 {
+			existing, loadErr := s.LoadTrustedKeys()
+			if loadErr != nil {
+				logger.Warnf("Failed to load stored trusted keys, replacing: %v", loadErr)
+			}
+			if saveErr := s.SaveTrustedKeys(mergeTrustedKeys(existing, keys, time.Now())); saveErr != nil {
+				logger.Errorf("Failed to save trusted keys to store: %v", saveErr)
 			}
 		}
 	}

--- a/internal/node/controlplane_test.go
+++ b/internal/node/controlplane_test.go
@@ -16,15 +16,46 @@ package node
 
 import (
 	"context"
+	"crypto/ed25519"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/sam/api"
 	"google.golang.org/protobuf/proto"
 )
+
+func TestMergeTrustedKeys(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-2 * time.Hour)
+	keyA, _, _ := ed25519.GenerateKey(nil)
+	keyB, _, _ := ed25519.GenerateKey(nil)
+	keyC, _, _ := ed25519.GenerateKey(nil)
+
+	existing := []TrustedKey{
+		{Key: keyA, ReceivedAt: earlier},
+		{Key: keyC, ReceivedAt: earlier}, // expired at the CP: absent from /keys
+	}
+	got := mergeTrustedKeys(existing, []ed25519.PublicKey{keyA, keyB}, now)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(got))
+	}
+	if !got[0].Key.Equal(keyA) || !got[0].ReceivedAt.Equal(earlier) {
+		t.Errorf("known key must keep its ReceivedAt: got %+v", got[0])
+	}
+	if !got[1].Key.Equal(keyB) || !got[1].ReceivedAt.Equal(now) {
+		t.Errorf("new key must get the sync time: got %+v", got[1])
+	}
+	for _, tk := range got {
+		if tk.Key.Equal(keyC) {
+			t.Error("key expired at the control plane must be dropped")
+		}
+	}
+}
 
 func TestFetchControlPlaneInfo(t *testing.T) {
 	expectedInfo := &api.ControlPlaneInfoResponse{
@@ -106,8 +137,19 @@ func TestSyncMeshConfig(t *testing.T) {
 		t.Fatalf("Failed to marshal info: %v", err)
 	}
 
+	cpPub, _, _ := ed25519.GenerateKey(nil)
+	gracePub, _, _ := ed25519.GenerateKey(nil)
+	keysBody, err := proto.Marshal(&api.KeysResponse{PublicKeys: [][]byte{cpPub, gracePub}})
+	if err != nil {
+		t.Fatalf("Failed to marshal keys: %v", err)
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == "/keys" {
+			_, _ = w.Write(keysBody)
+			return
+		}
 		_, _ = w.Write(body)
 	}))
 	defer server.Close()
@@ -158,6 +200,18 @@ func TestSyncMeshConfig(t *testing.T) {
 	}
 	if string(savedPubKey) != string(testPubKey) {
 		t.Errorf("Expected saved pubKey %s, got %s", testPubKey, savedPubKey)
+	}
+
+	// The full valid key set from /keys must have been persisted
+	trusted, err := store.LoadTrustedKeys()
+	if err != nil {
+		t.Fatalf("LoadTrustedKeys: %v", err)
+	}
+	if len(trusted) != 2 {
+		t.Fatalf("expected 2 trusted keys from /keys, got %d", len(trusted))
+	}
+	if !trusted[0].Key.Equal(cpPub) || !trusted[1].Key.Equal(gracePub) {
+		t.Errorf("persisted keys do not match /keys response")
 	}
 	if len(savedAddrsStr) != 1 || savedAddrsStr[0] != expectedInfo.RouterAddresses[0] {
 		t.Errorf("Expected saved addrs %v, got %v", expectedInfo.RouterAddresses, savedAddrsStr)

--- a/internal/node/enroll.go
+++ b/internal/node/enroll.go
@@ -154,9 +154,7 @@ func (n *SamNode) processEnrollResponse(resp *http.Response) (*api.EnrollRespons
 		return nil, fmt.Errorf("failed to save mesh config: %v", err)
 	}
 
-	n.keysMu.Lock()
-	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(enrollResp.ControlPlanePublicKey), ReceivedAt: time.Now()})
-	n.keysMu.Unlock()
+	n.addTrustedKey(ed25519.PublicKey(enrollResp.ControlPlanePublicKey))
 
 	return &enrollResp, nil
 }
@@ -335,9 +333,7 @@ func (n *SamNode) EnrollBootstrap(ctx context.Context, controlPlaneURL string, b
 		return fmt.Errorf("failed to save mesh config: %v", err)
 	}
 
-	n.keysMu.Lock()
-	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(enrollResp.ControlPlanePublicKey), ReceivedAt: time.Now()})
-	n.keysMu.Unlock()
+	n.addTrustedKey(ed25519.PublicKey(enrollResp.ControlPlanePublicKey))
 
 	// Connect and Auth to router after enrollment to join the mesh
 	if len(enrollResp.RouterAddresses) == 0 {

--- a/internal/node/enroll.go
+++ b/internal/node/enroll.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/sam/internal/identity"
 	golog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"google.golang.org/protobuf/proto"
 )
@@ -62,39 +63,50 @@ func GetOrGenerateKey(s *Store) crypto.PrivKey {
 
 func (n *SamNode) Enroll(ctx context.Context, controlPlaneURL string, jwt string) error {
 	pubKey := n.Host.Peerstore().PubKey(n.Host.ID())
+	enrollResp, err := n.enrollHTTP(ctx, controlPlaneURL, jwt, n.Host.ID(), pubKey)
+	if err != nil {
+		return err
+	}
+
+	return n.connectToRouters(ctx, enrollResp.RouterAddresses)
+}
+
+// enrollHTTP performs the HTTP half of enrollment for an explicit peer
+// identity, so it can run before the libp2p host exists (startup recovery).
+func (n *SamNode) enrollHTTP(ctx context.Context, controlPlaneURL, jwt string, peerID peer.ID, pubKey crypto.PubKey) (*api.EnrollResponse, error) {
 	pubBytes, err := crypto.MarshalPublicKey(pubKey)
 	if err != nil {
-		return fmt.Errorf("failed to marshal public key: %w", err)
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
 	}
 
 	req := &api.EnrollRequest{
 		Jwt:           jwt,
-		PeerId:        n.Host.ID().String(),
+		PeerId:        peerID.String(),
 		PublicKey:     pubBytes,
 		RequestedRole: n.config.RequiredRole,
 		Labels:        n.config.Labels, // validated at startup
 	}
 	data, err := proto.Marshal(req)
 	if err != nil {
-		return fmt.Errorf("failed to marshal enroll request: %v", err)
+		return nil, fmt.Errorf("failed to marshal enroll request: %v", err)
 	}
 
 	if !strings.HasPrefix(controlPlaneURL, "http://") && !strings.HasPrefix(controlPlaneURL, "https://") {
-		return fmt.Errorf("control plane address must be an HTTP or HTTPS URL for enrollment: %s", controlPlaneURL)
+		return nil, fmt.Errorf("control plane address must be an HTTP or HTTPS URL for enrollment: %s", controlPlaneURL)
 	}
 	url := controlPlaneURL + "/register"
 	logger.Infof("Enrolling via HTTP at %s", url)
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("failed to create HTTP request: %v", err)
+		return nil, fmt.Errorf("failed to create HTTP request: %v", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("HTTP request failed: %v", err)
+		return nil, fmt.Errorf("HTTP request failed: %v", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -102,12 +114,29 @@ func (n *SamNode) Enroll(ctx context.Context, controlPlaneURL string, jwt string
 		}
 	}()
 
-	enrollResp, err := n.processEnrollResponse(resp)
+	return n.processEnrollResponse(resp)
+}
+
+// recoverStaleIdentity re-enrolls over HTTP with a JWT obtained from the
+// stored refresh token, keeping the node's PeerID. It must not touch n.Host:
+// it runs before the host exists, and router connection happens in the
+// normal startup path afterwards.
+func (n *SamNode) recoverStaleIdentity(ctx context.Context) error {
+	controlPlaneURL, err := n.Store.LoadControlPlaneURL()
+	if err != nil || controlPlaneURL == "" {
+		return fmt.Errorf("no control plane URL in store")
+	}
+	jwt, err := n.renewWithRefreshToken(ctx, "")
 	if err != nil {
 		return err
 	}
-
-	return n.connectToRouters(ctx, enrollResp.RouterAddresses)
+	privKey := GetOrGenerateKey(n.Store)
+	peerID, err := peer.IDFromPublicKey(privKey.GetPublic())
+	if err != nil {
+		return fmt.Errorf("failed to derive peer ID from stored key: %w", err)
+	}
+	_, err = n.enrollHTTP(ctx, controlPlaneURL, jwt, peerID, privKey.GetPublic())
+	return err
 }
 
 func (n *SamNode) processEnrollResponse(resp *http.Response) (*api.EnrollResponse, error) {

--- a/internal/node/enroll_test.go
+++ b/internal/node/enroll_test.go
@@ -17,17 +17,213 @@ package node
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/google/sam/api"
+	"github.com/google/sam/internal/identity"
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"google.golang.org/protobuf/proto"
 )
+
+// TestStartRecoversStaleIdentityViaRefreshToken covers #321: a stored
+// identity signed by a fully rotated-out key must heal at startup through
+// refresh grant + HTTP re-enrollment, keeping the PeerID, instead of fataling.
+func TestStartRecoversStaleIdentityViaRefreshToken(t *testing.T) {
+	cpPub, cpPriv, _ := ed25519.GenerateKey(nil)
+	_, stalePriv, _ := ed25519.GenerateKey(nil)
+
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Fix the node keypair up front so the mock CP can assert PeerID is kept
+	privKey := GetOrGenerateKey(store)
+	wantPeerID, err := peer.IDFromPublicKey(privKey.GetPublic())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mint := func(priv ed25519.PrivateKey, peerID string) []byte {
+		builder := biscuit.NewBuilder(priv)
+		for _, f := range []biscuit.Fact{
+			{Predicate: biscuit.Predicate{Name: api.FactNode, IDs: []biscuit.Term{biscuit.String(peerID)}}},
+			{Predicate: biscuit.Predicate{Name: api.FactRole, IDs: []biscuit.Term{biscuit.String(api.RoleNode)}}},
+			{Predicate: biscuit.Predicate{Name: api.FactExpiration, IDs: []biscuit.Term{biscuit.Date(time.Now().Add(24 * time.Hour))}}},
+		} {
+			if err := builder.AddAuthorityFact(f); err != nil {
+				t.Fatalf("failed to add fact: %v", err)
+			}
+		}
+		tok, err := builder.Build()
+		if err != nil {
+			t.Fatalf("failed to build biscuit: %v", err)
+		}
+		b, err := tok.Serialize()
+		if err != nil {
+			t.Fatalf("failed to serialize biscuit: %v", err)
+		}
+		return b
+	}
+
+	// Stored identity is signed by a key the node no longer trusts
+	if err := store.SaveIdentity(mint(stalePriv, wantPeerID.String())); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock OIDC issuer honouring the refresh grant
+	oidcMux := http.NewServeMux()
+	oidcMux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 "http://" + r.Host,
+			"token_endpoint":         "http://" + r.Host + "/token",
+			"authorization_endpoint": "http://" + r.Host + "/auth",
+		})
+	})
+	oidcMux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "refresh_token" || r.FormValue("refresh_token") != "stored_refresh" {
+			http.Error(w, "invalid grant", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"access_token":  "unused",
+			"id_token":      "recovered_jwt",
+			"refresh_token": "rotated_refresh",
+		})
+	})
+	oidcSrv := httptest.NewServer(oidcMux)
+	defer oidcSrv.Close()
+
+	// Mock control plane: re-enrolls the peer with a freshly signed biscuit
+	var mu sync.Mutex
+	var gotPeerID, gotJWT string
+	cpMux := http.NewServeMux()
+	cpMux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req api.EnrollRequest
+		if err := proto.Unmarshal(body, &req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		gotPeerID, gotJWT = req.PeerId, req.Jwt
+		mu.Unlock()
+		resp := &api.EnrollResponse{
+			BiscuitToken:          mint(cpPriv, req.PeerId),
+			ControlPlanePublicKey: cpPub,
+			RouterAddresses:       []string{"/ip4/127.0.0.1/tcp/1"},
+			Expiration:            time.Now().Add(24 * time.Hour).Unix(),
+		}
+		data, _ := proto.Marshal(resp)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		_, _ = w.Write(data)
+	})
+	cpSrv := httptest.NewServer(cpMux)
+	defer cpSrv.Close()
+
+	if err := store.SaveOIDCConfig(oidcSrv.URL, "client_id_test", "sam"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveRefreshToken("stored_refresh"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveControlPlaneURL(cpSrv.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	node, err := NewSamNode(Options{
+		PrivKey:            privKey,
+		Store:              store,
+		ControlPlanePubKey: cpPub,
+		ListenAddrs:        []string{"/ip4/127.0.0.1/tcp/0"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := node.Start(ctx); err != nil {
+		t.Fatalf("Start should have recovered the stale identity, got: %v", err)
+	}
+
+	mu.Lock()
+	if gotPeerID != wantPeerID.String() {
+		t.Errorf("re-enrollment peer id: got %q, want %q (PeerID must survive recovery)", gotPeerID, wantPeerID)
+	}
+	if gotJWT != "recovered_jwt" {
+		t.Errorf("re-enrollment JWT: got %q, want refresh-grant token", gotJWT)
+	}
+	mu.Unlock()
+
+	if err := identity.VerifyBiscuitRole(node.GetIdentity(), cpPub, api.RoleNode, time.Second); err != nil {
+		t.Errorf("recovered identity does not verify under the current CP key: %v", err)
+	}
+}
+
+// Without a refresh token the startup failure must stay fatal.
+func TestStartStaleIdentityWithoutRefreshTokenFails(t *testing.T) {
+	cpPub, _, _ := ed25519.GenerateKey(nil)
+	_, stalePriv, _ := ed25519.GenerateKey(nil)
+
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	privKey := GetOrGenerateKey(store)
+	peerID, _ := peer.IDFromPublicKey(privKey.GetPublic())
+
+	builder := biscuit.NewBuilder(stalePriv)
+	_ = builder.AddAuthorityFact(biscuit.Fact{Predicate: biscuit.Predicate{Name: api.FactNode, IDs: []biscuit.Term{biscuit.String(peerID.String())}}})
+	_ = builder.AddAuthorityFact(biscuit.Fact{Predicate: biscuit.Predicate{Name: api.FactRole, IDs: []biscuit.Term{biscuit.String(api.RoleNode)}}})
+	tok, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleBiscuit, err := tok.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveIdentity(staleBiscuit); err != nil {
+		t.Fatal(err)
+	}
+
+	node, err := NewSamNode(Options{
+		PrivKey:            privKey,
+		Store:              store,
+		ControlPlanePubKey: cpPub,
+		ListenAddrs:        []string{"/ip4/127.0.0.1/tcp/0"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = node.Start(ctx)
+	if err == nil {
+		t.Fatal("Start should fail when recovery is impossible")
+	}
+	if !strings.Contains(err.Error(), "fails role requirement") {
+		t.Errorf("error should keep the role-requirement guidance, got: %v", err)
+	}
+}
 
 func TestGetOrGenerateKey(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/node/enroll_test.go
+++ b/internal/node/enroll_test.go
@@ -189,6 +189,15 @@ func TestStartRecoversStaleIdentityViaRefreshToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// A decoy key ahead of the real one: the router handshake must build its
+	// authorizer from the key that verified, not from trustedKeys[0].
+	decoyKey, _, _ := ed25519.GenerateKey(nil)
+	if err := store.SaveTrustedKeys([]TrustedKey{
+		{Key: decoyKey, ReceivedAt: time.Now()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	node, err := NewSamNode(Options{
 		PrivKey:            privKey,
 		Store:              store,

--- a/internal/node/enroll_test.go
+++ b/internal/node/enroll_test.go
@@ -30,10 +30,52 @@ import (
 	"github.com/biscuit-auth/biscuit-go/v2"
 	"github.com/google/sam/api"
 	"github.com/google/sam/internal/identity"
+	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-msgio"
 	"google.golang.org/protobuf/proto"
 )
+
+// startMockRouterWithKey runs a minimal router whose auth response biscuit is
+// signed by the given CP key, so nodes trusting that key can authenticate.
+func startMockRouterWithKey(t *testing.T, cpPriv ed25519.PrivateKey, role string) string {
+	t.Helper()
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
+	if err != nil {
+		t.Fatalf("failed to create mock router host: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Close() })
+
+	builder := biscuit.NewBuilder(cpPriv)
+	for _, f := range []biscuit.Fact{
+		{Predicate: biscuit.Predicate{Name: api.FactNode, IDs: []biscuit.Term{biscuit.String(h.ID().String())}}},
+		{Predicate: biscuit.Predicate{Name: api.FactRole, IDs: []biscuit.Term{biscuit.String(role)}}},
+		{Predicate: biscuit.Predicate{Name: api.FactExpiration, IDs: []biscuit.Term{biscuit.Date(time.Now().Add(24 * time.Hour))}}},
+		{Predicate: biscuit.Predicate{Name: api.FactTargetUnrestricted}},
+	} {
+		if err := builder.AddAuthorityFact(f); err != nil {
+			t.Fatalf("failed to add router fact: %v", err)
+		}
+	}
+	tok, err := builder.Build()
+	if err != nil {
+		t.Fatalf("failed to build router biscuit: %v", err)
+	}
+	routerBiscuit, err := tok.Serialize()
+	if err != nil {
+		t.Fatalf("failed to serialize router biscuit: %v", err)
+	}
+
+	h.SetStreamHandler(api.AuthProtocolID, func(s network.Stream) {
+		defer func() { _ = s.Close() }()
+		data, _ := proto.Marshal(&api.AuthResponse{Success: true, Biscuit: routerBiscuit})
+		_ = msgio.NewVarintWriter(s).WriteMsg(data)
+	})
+
+	return h.Addrs()[0].String() + "/p2p/" + h.ID().String()
+}
 
 // TestStartRecoversStaleIdentityViaRefreshToken covers #321: a stored
 // identity signed by a fully rotated-out key must heal at startup through
@@ -41,6 +83,8 @@ import (
 func TestStartRecoversStaleIdentityViaRefreshToken(t *testing.T) {
 	cpPub, cpPriv, _ := ed25519.GenerateKey(nil)
 	_, stalePriv, _ := ed25519.GenerateKey(nil)
+
+	routerAddr := startMockRouterWithKey(t, cpPriv, api.RoleRouter)
 
 	store, err := NewStore(t.TempDir())
 	if err != nil {
@@ -125,7 +169,7 @@ func TestStartRecoversStaleIdentityViaRefreshToken(t *testing.T) {
 		resp := &api.EnrollResponse{
 			BiscuitToken:          mint(cpPriv, req.PeerId),
 			ControlPlanePublicKey: cpPub,
-			RouterAddresses:       []string{"/ip4/127.0.0.1/tcp/1"},
+			RouterAddresses:       []string{routerAddr},
 			Expiration:            time.Now().Add(24 * time.Hour).Unix(),
 		}
 		data, _ := proto.Marshal(resp)
@@ -172,6 +216,12 @@ func TestStartRecoversStaleIdentityViaRefreshToken(t *testing.T) {
 
 	if err := identity.VerifyBiscuitRole(node.GetIdentity(), cpPub, api.RoleNode, time.Second); err != nil {
 		t.Errorf("recovered identity does not verify under the current CP key: %v", err)
+	}
+
+	// The router addresses from the re-enrollment must be adopted in-memory,
+	// not only persisted: the static relay setup runs right after recovery.
+	if len(node.config.RouterAddrs) != 1 || node.config.RouterAddrs[0].String() != routerAddr {
+		t.Errorf("recovered router addresses not adopted: got %v, want %s", node.config.RouterAddrs, routerAddr)
 	}
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -302,10 +302,29 @@ func NewSamNode(cfg Options) (*SamNode, error) {
 // Start initializes the libp2p host, DHT, connects to the routers, and starts runtime components.
 func (n *SamNode) Start(ctx context.Context) error {
 	if biscuitBytes := n.GetIdentity(); len(biscuitBytes) > 0 {
-		controlPlanePubKeyBytes, _, err := n.Store.LoadMeshConfig()
-		if err == nil && len(controlPlanePubKeyBytes) > 0 {
-			if err := identity.VerifyBiscuitRole(biscuitBytes, ed25519.PublicKey(controlPlanePubKeyBytes), n.config.RequiredRole, n.BiscuitTimeout); err != nil {
-				return fmt.Errorf("loaded identity fails role requirement %q: %w", n.config.RequiredRole, err)
+		// The identity may be signed by any currently valid control plane
+		// key, not only the newest: after a rotation the biscuit's key can
+		// legitimately be in its grace period.
+		n.keysMu.RLock()
+		candidates := make([]ed25519.PublicKey, 0, len(n.trustedKeys))
+		for _, tk := range n.trustedKeys {
+			candidates = append(candidates, tk.Key)
+		}
+		n.keysMu.RUnlock()
+		if len(candidates) == 0 {
+			if pubKeyBytes, _, err := n.Store.LoadMeshConfig(); err == nil && len(pubKeyBytes) > 0 {
+				candidates = append(candidates, ed25519.PublicKey(pubKeyBytes))
+			}
+		}
+		if len(candidates) > 0 {
+			var roleErr error
+			for _, key := range candidates {
+				if roleErr = identity.VerifyBiscuitRole(biscuitBytes, key, n.config.RequiredRole, n.BiscuitTimeout); roleErr == nil {
+					break
+				}
+			}
+			if roleErr != nil {
+				return fmt.Errorf("loaded identity fails role requirement %q: %w", n.config.RequiredRole, roleErr)
 			}
 		}
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -259,7 +259,15 @@ func NewSamNode(cfg Options) (*SamNode, error) {
 		if stored, err := cfg.Store.LoadTrustedKeys(); err != nil {
 			logger.Warnf("Failed to load persisted trusted keys: %v", err)
 		} else {
-			trustedKeys = stored
+			for _, tk := range stored {
+				// A corrupt entry must not reach ed25519 verification (panics
+				// on wrong-size keys).
+				if len(tk.Key) == ed25519.PublicKeySize {
+					trustedKeys = append(trustedKeys, tk)
+				} else {
+					logger.Warnf("Ignoring persisted trusted key with invalid size %d", len(tk.Key))
+				}
+			}
 		}
 	}
 	if len(cfg.ControlPlanePubKey) > 0 && !containsTrustedKey(trustedKeys, cfg.ControlPlanePubKey) {
@@ -312,7 +320,7 @@ func (n *SamNode) Start(ctx context.Context) error {
 		}
 		n.keysMu.RUnlock()
 		if len(candidates) == 0 {
-			if pubKeyBytes, _, err := n.Store.LoadMeshConfig(); err == nil && len(pubKeyBytes) > 0 {
+			if pubKeyBytes, _, err := n.Store.LoadMeshConfig(); err == nil && len(pubKeyBytes) == ed25519.PublicKeySize {
 				candidates = append(candidates, ed25519.PublicKey(pubKeyBytes))
 			}
 		}
@@ -332,6 +340,19 @@ func (n *SamNode) Start(ctx context.Context) error {
 					return fmt.Errorf("loaded identity fails role requirement %q (refresh-token recovery failed: %v): %w", n.config.RequiredRole, recErr, roleErr)
 				}
 				logger.Info("Identity recovered via refresh-token re-enrollment.")
+				// Re-enrollment persisted the response's router addresses; adopt
+				// them so the static relay setup below doesn't use stale ones.
+				if _, storedAddrs, loadErr := n.Store.LoadMeshConfig(); loadErr == nil {
+					var addrs []multiaddr.Multiaddr
+					for _, addrStr := range storedAddrs {
+						if ma, parseErr := multiaddr.NewMultiaddr(addrStr); parseErr == nil {
+							addrs = append(addrs, ma)
+						}
+					}
+					if len(addrs) > 0 {
+						n.config.RouterAddrs = addrs
+					}
+				}
 			}
 		}
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -903,13 +903,15 @@ func (n *SamNode) performRouterAuthHandshake(s network.Stream, biscuitBytes []by
 	}
 
 	// Verify the router's biscuit using the control plane keys
-	b, err := identity.VerifyBiscuit(resp.Biscuit, expectedRouter, trustedKeys, n.BiscuitTimeout)
+	b, verifiedKey, err := identity.VerifyBiscuitAndGetKey(resp.Biscuit, expectedRouter, trustedKeys, n.BiscuitTimeout)
 	if err != nil {
 		return false, fmt.Errorf("%w: failed to verify router biscuit: %w", ErrFatalAuth, err)
 	}
 
-	// Enforce role("router") inside the biscuit
-	authorizer, err := b.Authorizer(trustedKeys[0], identity.AuthorizerOptions(n.BiscuitTimeout)...)
+	// Enforce role("router") inside the biscuit, under the key that verified:
+	// with several valid keys loaded (rotation grace) the first is not
+	// necessarily the signer.
+	authorizer, err := b.Authorizer(verifiedKey, identity.AuthorizerOptions(n.BiscuitTimeout)...)
 	if err != nil {
 		return false, fmt.Errorf("authorizer instantiation failed: %w", err)
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1246,6 +1246,29 @@ func (n *SamNode) handleKeyRotationEvent(event *api.MeshEvent) {
 	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(event.NewPublicKey), ReceivedAt: time.Now()})
 }
 
+// pruneTrustedKeys drops keys older than gracePeriod but always keeps the
+// most recently received one: the current signing key has no successor until
+// a rotation event arrives, so ageing it out would empty the trust set and
+// leave the node unable to verify any peer or router.
+func pruneTrustedKeys(keys []TrustedKey, now time.Time, gracePeriod time.Duration) []TrustedKey {
+	if len(keys) == 0 {
+		return keys
+	}
+	newest := 0
+	for i, tk := range keys {
+		if tk.ReceivedAt.After(keys[newest].ReceivedAt) {
+			newest = i
+		}
+	}
+	var active []TrustedKey
+	for i, tk := range keys {
+		if i == newest || now.Sub(tk.ReceivedAt) <= gracePeriod {
+			active = append(active, tk)
+		}
+	}
+	return active
+}
+
 func (n *SamNode) startKeyPruning(ctx context.Context, gracePeriod time.Duration) {
 	if gracePeriod <= 0 {
 		return
@@ -1258,14 +1281,7 @@ func (n *SamNode) startKeyPruning(ctx context.Context, gracePeriod time.Duration
 			case <-ticker.C:
 				logger.Info("[KeyPruning] Pruning expired keys...")
 				n.keysMu.Lock()
-				now := time.Now()
-				var activeKeys []TrustedKey
-				for _, tk := range n.trustedKeys {
-					if now.Sub(tk.ReceivedAt) <= gracePeriod {
-						activeKeys = append(activeKeys, tk)
-					}
-				}
-				n.trustedKeys = activeKeys
+				n.trustedKeys = pruneTrustedKeys(n.trustedKeys, time.Now(), gracePeriod)
 				n.keysMu.Unlock()
 			case <-ctx.Done():
 				return

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -324,7 +324,14 @@ func (n *SamNode) Start(ctx context.Context) error {
 				}
 			}
 			if roleErr != nil {
-				return fmt.Errorf("loaded identity fails role requirement %q: %w", n.config.RequiredRole, roleErr)
+				// Stale identity (e.g. signing key rotated past its grace
+				// period while offline): try silent re-enrollment with the
+				// stored refresh token before giving up.
+				logger.Warnf("Loaded identity fails role requirement %q: %v; attempting recovery via stored refresh token", n.config.RequiredRole, roleErr)
+				if recErr := n.recoverStaleIdentity(ctx); recErr != nil {
+					return fmt.Errorf("loaded identity fails role requirement %q (refresh-token recovery failed: %v): %w", n.config.RequiredRole, recErr, roleErr)
+				}
+				logger.Info("Identity recovered via refresh-token re-enrollment.")
 			}
 		}
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -255,8 +255,15 @@ func NewSamNode(cfg Options) (*SamNode, error) {
 	}
 
 	var trustedKeys []TrustedKey
-	if len(cfg.ControlPlanePubKey) > 0 {
-		trustedKeys = []TrustedKey{{Key: cfg.ControlPlanePubKey, ReceivedAt: time.Now()}}
+	if cfg.Store != nil {
+		if stored, err := cfg.Store.LoadTrustedKeys(); err != nil {
+			logger.Warnf("Failed to load persisted trusted keys: %v", err)
+		} else {
+			trustedKeys = stored
+		}
+	}
+	if len(cfg.ControlPlanePubKey) > 0 && !containsTrustedKey(trustedKeys, cfg.ControlPlanePubKey) {
+		trustedKeys = append(trustedKeys, TrustedKey{Key: cfg.ControlPlanePubKey, ReceivedAt: time.Now()})
 	}
 
 	node := &SamNode{
@@ -1230,20 +1237,45 @@ func (n *SamNode) handleBannedEvent(event *api.MeshEvent) {
 	}
 }
 
+func containsTrustedKey(keys []TrustedKey, key ed25519.PublicKey) bool {
+	for _, tk := range keys {
+		if bytes.Equal(tk.Key, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// addTrustedKey appends a control plane public key to the trust set (no-op
+// on duplicates) and persists the updated set so it survives restarts.
+func (n *SamNode) addTrustedKey(key ed25519.PublicKey) {
+	n.keysMu.Lock()
+	if containsTrustedKey(n.trustedKeys, key) {
+		n.keysMu.Unlock()
+		return
+	}
+	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: key, ReceivedAt: time.Now()})
+	snapshot := append([]TrustedKey(nil), n.trustedKeys...)
+	n.keysMu.Unlock()
+	n.persistTrustedKeys(snapshot)
+}
+
+func (n *SamNode) persistTrustedKeys(keys []TrustedKey) {
+	if n.Store == nil {
+		return
+	}
+	if err := n.Store.SaveTrustedKeys(keys); err != nil {
+		logger.Errorf("Failed to persist trusted keys: %v", err)
+	}
+}
+
 func (n *SamNode) handleKeyRotationEvent(event *api.MeshEvent) {
 	if len(event.NewPublicKey) != ed25519.PublicKeySize {
 		logger.Errorf("[Mesh Event] Key rotation failed: invalid public key size %d, expected %d", len(event.NewPublicKey), ed25519.PublicKeySize)
 		return
 	}
 	logger.Infow("[Mesh Event] key rotation received", "event", meshEventKeyRotation, "key", fmt.Sprintf("%x", event.NewPublicKey))
-	n.keysMu.Lock()
-	defer n.keysMu.Unlock()
-	for _, tk := range n.trustedKeys {
-		if bytes.Equal(tk.Key, event.NewPublicKey) {
-			return // Ignore duplicate
-		}
-	}
-	n.trustedKeys = append(n.trustedKeys, TrustedKey{Key: ed25519.PublicKey(event.NewPublicKey), ReceivedAt: time.Now()})
+	n.addTrustedKey(ed25519.PublicKey(event.NewPublicKey))
 }
 
 // pruneTrustedKeys drops keys older than gracePeriod but always keeps the
@@ -1281,8 +1313,14 @@ func (n *SamNode) startKeyPruning(ctx context.Context, gracePeriod time.Duration
 			case <-ticker.C:
 				logger.Info("[KeyPruning] Pruning expired keys...")
 				n.keysMu.Lock()
-				n.trustedKeys = pruneTrustedKeys(n.trustedKeys, time.Now(), gracePeriod)
+				pruned := pruneTrustedKeys(n.trustedKeys, time.Now(), gracePeriod)
+				changed := len(pruned) != len(n.trustedKeys)
+				n.trustedKeys = pruned
+				snapshot := append([]TrustedKey(nil), pruned...)
 				n.keysMu.Unlock()
+				if changed {
+					n.persistTrustedKeys(snapshot)
+				}
 			case <-ctx.Done():
 				return
 			}

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -145,6 +145,49 @@ func TestHandleKeyRotationEvent(t *testing.T) {
 	}
 }
 
+// TestKeyRotationEventSurvivesRestart covers the offline/restart half of
+// #325: a key learned from a rotation event must outlive the process, or a
+// restarted node falls back to its stale enrollment-time key.
+func TestKeyRotationEventSurvivesRestart(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	enrollKey, _, _ := ed25519.GenerateKey(nil)
+	rotatedKey, _, _ := ed25519.GenerateKey(nil)
+
+	node := &SamNode{Store: store, trustedKeys: []TrustedKey{{Key: enrollKey, ReceivedAt: time.Now()}}}
+	node.handleKeyRotationEvent(&api.MeshEvent{
+		Type:         api.MeshEvent_KEY_ROTATION,
+		NewPublicKey: rotatedKey,
+		Timestamp:    time.Now().UnixMilli(),
+	})
+	// Duplicate event must not grow the persisted set
+	node.handleKeyRotationEvent(&api.MeshEvent{
+		Type:         api.MeshEvent_KEY_ROTATION,
+		NewPublicKey: rotatedKey,
+		Timestamp:    time.Now().UnixMilli(),
+	})
+
+	// "Restart": a fresh node built from the same store must trust the rotated key
+	priv, _, _ := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	restarted, err := NewSamNode(Options{PrivKey: priv, Store: store, ControlPlanePubKey: enrollKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(restarted.trustedKeys) != 2 {
+		t.Fatalf("expected 2 trusted keys after restart, got %d", len(restarted.trustedKeys))
+	}
+	if !containsTrustedKey(restarted.trustedKeys, rotatedKey) {
+		t.Error("rotated key lost across restart")
+	}
+	if !containsTrustedKey(restarted.trustedKeys, enrollKey) {
+		t.Error("enrollment key missing after restart")
+	}
+}
+
 // TestPruneTrustedKeys covers the trust-set floor: a node that runs past the
 // grace period without witnessing a rotation must not age out its only key.
 func TestPruneTrustedKeys(t *testing.T) {

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -145,6 +145,51 @@ func TestHandleKeyRotationEvent(t *testing.T) {
 	}
 }
 
+// TestPruneTrustedKeys covers the trust-set floor: a node that runs past the
+// grace period without witnessing a rotation must not age out its only key.
+func TestPruneTrustedKeys(t *testing.T) {
+	now := time.Now()
+	grace := 24 * time.Hour
+	k := func(age time.Duration) TrustedKey {
+		pub, _, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return TrustedKey{Key: pub, ReceivedAt: now.Add(-age)}
+	}
+
+	stale := k(48 * time.Hour)
+	staler := k(72 * time.Hour)
+	fresh := k(time.Hour)
+
+	tests := []struct {
+		name string
+		in   []TrustedKey
+		want []TrustedKey
+	}{
+		{"sole stale key survives", []TrustedKey{stale}, []TrustedKey{stale}},
+		{"stale dropped when fresher exists", []TrustedKey{staler, fresh}, []TrustedKey{fresh}},
+		{"newest of two stale keys survives", []TrustedKey{staler, stale}, []TrustedKey{stale}},
+		{"fresh keys all kept", []TrustedKey{fresh, k(2 * time.Hour)}, nil}, // want computed below
+		{"empty", nil, nil},
+	}
+	tests[3].want = tests[3].in
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pruneTrustedKeys(tt.in, now, grace)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d keys, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if !got[i].Key.Equal(tt.want[i].Key) {
+					t.Errorf("key %d: got %x, want %x", i, got[i].Key, tt.want[i].Key)
+				}
+			}
+		})
+	}
+}
+
 // TestVerifyBiscuitRejectsExpiredToken covers the peer-admission half of #296:
 // HandleAuthHandshake admits a peer into authPeers, which the relay ACL then
 // trusts, so it must reject an expired token exactly like the dataplane does.

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -188,6 +188,31 @@ func TestKeyRotationEventSurvivesRestart(t *testing.T) {
 	}
 }
 
+func TestNewSamNodeIgnoresCorruptPersistedKeys(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	goodKey, _, _ := ed25519.GenerateKey(nil)
+	if err := store.SaveTrustedKeys([]TrustedKey{
+		{Key: []byte("corrupt"), ReceivedAt: time.Now()},
+		{Key: goodKey, ReceivedAt: time.Now()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	priv, _, _ := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+	node, err := NewSamNode(Options{PrivKey: priv, Store: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(node.trustedKeys) != 1 || !node.trustedKeys[0].Key.Equal(goodKey) {
+		t.Fatalf("expected only the valid key to survive loading, got %d keys", len(node.trustedKeys))
+	}
+}
+
 // TestPruneTrustedKeys covers the trust-set floor: a node that runs past the
 // grace period without witnessing a rotation must not age out its only key.
 func TestPruneTrustedKeys(t *testing.T) {

--- a/internal/node/store.go
+++ b/internal/node/store.go
@@ -39,6 +39,7 @@ const (
 	keyOidcIssuer   = "oidc_issuer"
 	keyOidcClientID = "oidc_client_id"
 	keyOidcAudience = "oidc_audience"
+	keyTrustedKeys  = "trusted_keys"
 )
 
 type Store struct {
@@ -239,6 +240,33 @@ func (s *Store) SaveControlPlaneURL(url string) error {
 	})
 }
 
+// SaveTrustedKeys persists the full set of control plane public keys the
+// node currently trusts, so keys learned from rotation events or /keys
+// survive restarts (the singular mesh-config key only tracks enrollment).
+func (s *Store) SaveTrustedKeys(keys []TrustedKey) error {
+	data, err := json.Marshal(keys)
+	if err != nil {
+		return err
+	}
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(bucketIdentity))
+		return b.Put([]byte(keyTrustedKeys), data)
+	})
+}
+
+func (s *Store) LoadTrustedKeys() ([]TrustedKey, error) {
+	var keys []TrustedKey
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(bucketIdentity))
+		data := b.Get([]byte(keyTrustedKeys))
+		if len(data) == 0 {
+			return nil
+		}
+		return json.Unmarshal(data, &keys)
+	})
+	return keys, err
+}
+
 func (s *Store) LoadControlPlaneURL() (string, error) {
 	var val []byte
 	err := s.db.View(func(tx *bbolt.Tx) error {
@@ -263,6 +291,7 @@ func (s *Store) ResetMeshIdentity() error {
 			keyOidcIssuer,
 			keyOidcClientID,
 			keyOidcAudience,
+			keyTrustedKeys,
 			"control_plane_public_key",
 			"router_addresses",
 			"control_plane_url",

--- a/internal/node/store_test.go
+++ b/internal/node/store_test.go
@@ -16,12 +16,14 @@ package node
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.etcd.io/bbolt"
@@ -42,6 +44,57 @@ func TestStore_NewStore_And_Close(t *testing.T) {
 
 	if err := store.Close(); err != nil {
 		t.Errorf("Failed to close store: %v", err)
+	}
+}
+
+func TestStore_TrustedKeys(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Empty store: no keys, no error
+	keys, err := store.LoadTrustedKeys()
+	if err != nil {
+		t.Fatalf("LoadTrustedKeys on empty store: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected no keys, got %d", len(keys))
+	}
+
+	pub1, _, _ := ed25519.GenerateKey(nil)
+	pub2, _, _ := ed25519.GenerateKey(nil)
+	want := []TrustedKey{
+		{Key: pub1, ReceivedAt: time.Now().Add(-time.Hour).UTC().Truncate(time.Second)},
+		{Key: pub2, ReceivedAt: time.Now().UTC().Truncate(time.Second)},
+	}
+	if err := store.SaveTrustedKeys(want); err != nil {
+		t.Fatalf("SaveTrustedKeys: %v", err)
+	}
+	got, err := store.LoadTrustedKeys()
+	if err != nil {
+		t.Fatalf("LoadTrustedKeys: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d keys, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if !got[i].Key.Equal(want[i].Key) || !got[i].ReceivedAt.Equal(want[i].ReceivedAt) {
+			t.Errorf("key %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// Mesh reset must clear the persisted trust set
+	if err := store.ResetMeshIdentity(); err != nil {
+		t.Fatalf("ResetMeshIdentity: %v", err)
+	}
+	got, err = store.LoadTrustedKeys()
+	if err != nil {
+		t.Fatalf("LoadTrustedKeys after reset: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected trust set cleared after mesh reset, got %d keys", len(got))
 	}
 }
 


### PR DESCRIPTION
Fixes #325, fixes #321. Four commits, each independently red/green verified.

Investigating #325 turned up that the control plane already serves the full valid key set on `/keys` (`KeysResponse`, `GetAllValidKeys`) and routers already sync from it — the node was the only component not using it, so **no proto change was needed**. It also turned up a latent bug worse than anything reported:

1. **`fix(node): never prune the newest trusted control plane key`** — key pruning aged out *every* key older than the grace period, including the current one: any node running >24h (default) without witnessing a rotation event emptied its own trust set and failed biscuit verification in both directions. This matches the simultaneous two-node failure observed on the hub. The most recently received key is now never pruned.

2. **`fix(node): persist the trusted control plane key set`** — keys learned from KEY_ROTATION events lived only in memory and enrollment persisted only the newest key, so restarts and offline windows silently reverted the trust set. The full set is now stored (written on enrollment/rotation/pruning, loaded in `NewSamNode`, cleared by `ResetMeshIdentity`), and duplicate rotation events dedup.

3. **`feat(node): sync the valid control plane key set from /keys`** — `SyncMeshConfig` now fetches `/keys` (the routers' existing catch-up path) and persists it, preserving `ReceivedAt` for known keys; empty/failed fetches never wipe the cached set. This fixes the #325 headline: a freshly enrolled node gets only the newest key while routers legitimately present grace-period biscuits — 'no valid key found' that re-enrollment cannot fix. The startup role check also accepts any trusted key, not only the newest. `SyncMeshConfig`'s signature is unchanged (no callers touched, incl. mobile FFI).

4. **`feat(node): recover a stale identity at startup via the refresh token`** (#321) — on role-requirement failure at startup, run the stored refresh grant and re-enroll over HTTP before dying. The libp2p host doesn't exist yet at that point, so enrollment's HTTP half is extracted into `enrollHTTP` taking an explicit peer identity; the PeerID is preserved (asserted by the test's mock CP). No/rejected refresh token keeps today's fatal error. Red run reproduces morewax's exact symptom: `loaded identity fails role requirement "sam:role:node": ... biscuit: invalid signature`.

Tests: table-driven units for pruning/merge/persistence, store round-trips, restart-survival, and two `Start()`-level recovery tests with mock OIDC + control plane. `TestKeyRotationIntegration` (4s rotation / 2s grace) and the datapath integration tests pass unchanged.

Remaining from #325: the ask to check the hub's live signing state is an ops action on the deployment, not addressed by this PR.