### PR TITLE
docs: clarify required discovery service type

### DIFF
--- a/internal/node/mcp_handlers.go
+++ b/internal/node/mcp_handlers.go
@@ -66,7 +66,7 @@ const inferenceInvocationHint = `To call an inference service, send a normal HTT
 
 // DiscoverRemoteServicesParams defines the parameters for the discover_remote_services tool.
 type DiscoverRemoteServicesParams struct {
-	Type   string `json:"type" jsonschema:"Service type (mcp, inference, a2a)"`
+	Type   string `json:"type" jsonschema:"Required. One of: mcp, inference, a2a."`
 	Name   string `json:"name,omitempty" jsonschema:"Optional service name. Omit to list all services of the given type."`
 	Limit  int    `json:"limit,omitempty" jsonschema:"Optional limit for pagination. Defaults to 20."`
 	Offset int    `json:"offset,omitempty" jsonschema:"Optional offset for pagination. Defaults to 0."`


### PR DESCRIPTION
## Summary

- mark type as required in the discover_remote_services input schema description
- list the three accepted values so schema-validation errors are self-explanatory

Addresses #322.

## Testing

- go test ./internal/node -run TestHandleDiscoverRemoteServices -count=1
- gofmt -d internal/node/mcp_handlers.go

A full go test ./internal/node run was also attempted; an unrelated macOS-only test setup failure occurs because the generated Unix socket path is 119 bytes while the kernel limit is 103.