### PR TITLE
docs: clarify digital sovereignty architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ Full walkthrough: [Warm Agent Pool use case](site/content/docs/use-cases/warm-ag
 
 ---
 
+## What "Sovereign" Means in SAM
+
+SAM is an **open-source software project (Apache-2.0)** providing decentralized networking and cryptographic building blocks for autonomous AI agents. It carries no vendor telemetry and has no hardcoded dependencies on proprietary cloud services or model providers.
+
+SAM provides the open protocols, cryptographic building blocks, and software to build **sovereign, zero-trust agent meshes**. In SAM, digital sovereignty is built on architectural and cryptographic control—custody of root keys, independent identity federation, and policy-enforced data boundaries. In a sovereign deployment, operators:
+
+1. **Deploy Dedicated Mesh Infrastructure:** Run a dedicated control plane (`sam-control-plane`) and routing relays (`sam-router`) on your chosen infrastructure (managed cloud environments like Google Cloud, private Kubernetes clusters, or air-gapped datacenters) using our [Helm chart](charts/sam-mesh/README.md) or Kubernetes manifests.
+2. **Maintain Root Cryptographic Key Custody:** Generate, manage, and hold your own Ed25519 root signing keys (via local HSMs, KMS, or Cloud EKM). You maintain 100% of the cryptographic authority—no external party can mint credentials, revoke nodes, or alter policies.
+3. **Bring Your Own Identity Provider:** Bridge agent and user identities through your own OIDC identity provider (such as Dex, Keycloak, or corporate IdP).
+4. **Enforce Territorial & Jurisdictional Boundaries:** Use cryptographically attested label gates (`--labels jurisdiction=eu`, `X-Sam-Required-Labels`) to mathematically guarantee prompts and tool invocations never leave authorized geographic scopes.
+5. **Retain Autonomous Local Vetoes:** Configure local node attenuation policies (`sam-node.yaml`) to evaluate access rules *before* control plane grants, ensuring local nodes retain absolute veto authority.
+
+> [!NOTE]
+> **About the Public Developer Testnets:**
+> The public endpoints (`bananas.sam-mesh.dev` and `hub.sam-mesh.dev`) are free testbeds created using community resources solely for developer testing, continuous integration, and rapid experimentation. They provide **no guarantees, no uptime commitments, zero SLA, and no sovereign guarantees**. Running on a shared community testnet delegates identity management to the testbed maintainers; true sovereignty requires deploying a dedicated control plane with customer-held keys.
+>
+> 📖 **Deep Dive:** Read our full **[Digital & Data Sovereignty Architecture](site/content/docs/sovereignty.md)** covering the 5 pillars, fail-closed label gates, uncooperative sandbox confinement, and regulatory alignment (GDPR Chapter V, EU Cloud Sovereignty Framework SEAL-3, EU Data Act).
+
+---
+
 ## Architecture Components
 
 *   `sam-control-plane`: The registry control plane for node identity registration, authorization policies, and router coordinating.
@@ -36,12 +56,14 @@ Full walkthrough: [Warm Agent Pool use case](site/content/docs/use-cases/warm-ag
 
 Start exploring the Sovereign Agent Mesh:
 
+### Digital & Data Sovereignty
+- 🏛️ **[Digital & Data Sovereignty Architecture](site/content/docs/sovereignty.md)**: How SAM enforces data residency, territorial label gates, autonomous local vetoes, and regulatory compliance (GDPR, EU Cloud Sovereignty Framework SEAL-3, EU Data Act).
+
 ### For Users & Operators
-Get a node running on the public testnet (`bananas.sam-mesh.dev`) in minutes:
-- 🚀 **[User Quick Start Guide](site/content/docs/quickstart.md)**: Connect and run a SAM node using binaries or Docker, and query the local MCP server.
+- 🚀 **[User Quick Start Guide](site/content/docs/quickstart.md)**: Connect and run a SAM node on the community-hosted developer testnet (`bananas.sam-mesh.dev`, strictly for testing with no guarantees) using binaries or Docker.
+- 🎛️ **[Dedicated Sovereign Deployment](site/content/docs/user/kubernetes-deployment.md)**: Run your own private sovereign hub (control plane, router, console) via the [sam-mesh Helm chart](charts/sam-mesh/README.md) or Kubernetes manifests.
 - 🤖 **[Agent Integration Guides](site/content/docs/integrations/_index.md)**: Connect Google Gemini, Claude, and other AI agents to your SAM node to dynamically discover and call tools across the mesh.
-- 📡 **[Testnet Validation Tutorial](site/content/docs/development/testnet-validation.md)**: Real-time verification, remote tool invocation, and HTTP stream proxies.
-- 🎛️ **[Production Kubernetes Deployment](site/content/docs/user/kubernetes-deployment.md)**: Run your own hub (control plane, router, console) via plain manifests, or via the [sam-mesh Helm chart](charts/sam-mesh/README.md) for local/self-hosted setups.
+- 📡 **[Testnet Validation Tutorial](site/content/docs/development/testnet-validation.md)**: Real-time verification, remote tool invocation, and HTTP stream proxies on public developer testnets.
 
 ### For Developers & Contributors
 Compile from source, run local clusters, or execute tests:

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -8,25 +8,29 @@ SAM (Sovereign Agent Mesh) is a smart, zero-config, zero-trust P2P network built
 
 Instead of exposing your agent's tools (like local scripts, LLM endpoints, or internal APIs) to the public internet, SAM allows you to create secure, private mesh networks. This is especially critical because modern AI agents operate across highly heterogeneous environments—spanning cloud servers, on-premises datacenters, personal laptops, Raspberry Pis, and Android devices. SAM seamlessly connects them all, regardless of complex network topologies or NATs.
 
-**Security & Trust Boundaries (Read This First!)**
+**Security & Sovereignty Fundamentals**
+* **Open Source Project:** SAM is an open-source project (Apache-2.0). It carries no vendor telemetry, has no proprietary lock-in, and can be deployed on any cloud, on-premises datacenter, or air-gapped environment.
 * **Isolated by Default:** You do NOT join any mesh by default. You must explicitly configure the control plane you want to join.
 * **Closed by Default:** Joining a mesh does not expose your tools. By default, your node does not allow any services to be reached by others. You must explicitly configure policies to share tools.
-* **Bring Your Own Control Plane (DIY):** While we offer public testnets, the core design allows you to host your own SAM control plane. You retain 100% control over your data, identities, and authorization policies.
+* **Public Testnets vs. Sovereign Deployments:** Public testnets (`bananas.sam-mesh.dev`, `hub.sam-mesh.dev`) are created using donated community resources solely as developer playgrounds for CI and experimentation. They hold zero production value, offer no guarantees or SLA, and carry no sovereignty. True sovereignty is achieved by deploying a dedicated control plane and routers with customer-managed cryptographic keys on your chosen infrastructure.
+* 🏛️ **[Digital & Data Sovereignty Architecture](sovereignty/)**: Read our detailed breakdown on territorial attestation, jurisdictional label gates, local vetoes, and regulatory alignment.
 
 ---
 
 ## Where to Start
 
-### "Easy Mode" (Public Testnet)
-For the fastest way to get started and experiment, you can join our public beta testnet (`bananas.sam-mesh.dev`). *Note: While convenient, remember this is a public testnet. Ensure you only expose tools you are comfortable sharing in a testing environment.*
+### "Developer Testnet Mode" (Ephemeral Testing Sandbox)
+For the fastest way to get started and experiment with the open-source code, you can connect a node to our public developer testnet (`bananas.sam-mesh.dev`). *Note: This is a shared developer testbed created with community resources. There are no guarantees; it is strictly for testing. Do not expose sensitive or production tools in a public testing environment.*
 
 - 🚀 **[User Quick Start Guide](quickstart/)**: Connect and run a SAM node using binaries or Docker, and query the local MCP server.
 - 🤖 **[Agent Integration Guide](user/agent-usage/)**: Connect Google Gemini, Claude, and other AI agents to your SAM node to call tools across the mesh.
 - 📡 **[Testnet Validation Tutorial](development/testnet-validation/)**: Real-time verification, remote tool invocation, and HTTP stream proxies.
 
-### "DIY Mode" (Self-Hosted for Developers & Operators)
-Compile from source, run local clusters, host your own control plane, or execute tests:
-- 🛠️ **[Developer Guide](development/)**: Prereqs, compilation, local control plane setup, and Kubernetes Kind deployment.
+### "Dedicated Sovereign Deployment Mode" (For Production & Private Meshes)
+Deploy your own control plane, manage your own keys, and retain 100% cryptographic authority:
+- 🏛️ **[Digital & Data Sovereignty Guide](sovereignty/)**: Deep-dive into jurisdictional label gates, local veto attenuation, uncooperative sandbox boundaries, and compliance.
+- 🎛️ **[Production Kubernetes Deployment](user/kubernetes-deployment/)**: Deploy your own control plane and routers via Helm or Kubernetes manifests.
+- 🛠️ **[Developer Guide](development/)**: Prereqs, compilation, local control plane setup, and Kind deployment.
 - 🧪 **[Testing Guide](development/testing/)**: Go tests, E2E BATS, and containerized mesh execution.
 
 ---

--- a/site/content/docs/development/release-tracks.md
+++ b/site/content/docs/development/release-tracks.md
@@ -6,24 +6,27 @@ Sovereign Agent Mesh (SAM) is deployed to public endpoints using automated envir
 
 ---
 
-## 1. Release Tracks
+## 1. Public Developer Testnets
 
-The public deployment has two isolated release tracks:
+> [!NOTE]
+> **Developer Testnets Disclaimer:**
+> Both public endpoints (`bananas.sam-mesh.dev` and `hub.sam-mesh.dev`) are **developer testnets created using community resources**. They are provided solely for testing, continuous integration, and rapid experimentation with the open-source codebase. They carry **no guarantees, no uptime commitments, and zero SLA**, and are not sovereign. For production workloads or strict data sovereignty, operators should deploy a dedicated mesh with customer-held keys using the [Helm chart](https://github.com/google/sam/tree/main/charts/sam-mesh) or [Kubernetes deployment guide](../user/kubernetes-deployment/). See [Digital & Data Sovereignty](../sovereignty/) for full architectural details.
 
-### A. Testnet Track (Bananas)
+The public developer deployment maintains two isolated testnet tracks:
+
+### A. Bleeding-Edge Testnet Track (Bananas)
 *   **Domain Name:** `bananas.sam-mesh.dev`
 *   **Source Branch:** Tracks the `main` branch.
 *   **Deployment Trigger:** Automatically deployed on every new push/commit to the `main` branch.
 *   **Target Tag:** The deployment is tagged with the Git commit SHA (`github.sha`).
-*   **Purpose:** Serves as the staging/testing playground for the latest features and continuous integration.
+*   **Purpose:** Serves as the continuous integration and staging testbed for the latest unreleased features.
 
-### B. Production Track (Hub)
+### B. Release-Tagged Testnet Track (Hub)
 *   **Domain Name:** `hub.sam-mesh.dev`
 *   **Source Branch:** Tracks semantic version tags matching `v*.*.*`.
 *   **Deployment Trigger:** Automatically deployed whenever a new version tag is pushed to GitHub.
 *   **Target Tag:** The deployment is tagged with the exact Git release tag (e.g. `v1.0.0`).
-*   **Purpose:** Stable, audited release track for production workloads.
-
+*   **Purpose:** Public testbed running tagged releases for developer interoperability testing.
 ---
 
 ## 2. Autoupdate Mechanism

--- a/site/content/docs/development/testnet-validation.md
+++ b/site/content/docs/development/testnet-validation.md
@@ -4,6 +4,10 @@ linkTitle: "Testnet & Mesh Validation Tutorial"
 ---
 This tutorial guides you through validating your local environment integration with the public Sovereign Agent Mesh (SAM) testnets (`bananas.sam-mesh.dev` or `hub.sam-mesh.dev`). You will learn how to verify your node's connection, discover remote MCP services, and invoke remote tools.
 
+> [!NOTE]
+> **Community Testnet Notice:**
+> The public testnets are hosted using community resources and are provided strictly for developer testing, debugging, and experimentation. There are **no guarantees, uptime warranties, or SLA**. Do not deploy production agents or transmit sensitive data on public testnets.
+
 ---
 
 ## Prerequisites

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -10,7 +10,7 @@ This guide gets you up and running with a SAM node connected to the public `bana
 
 > [!NOTE]
 > **Developer Testnet Notice:**
-> `bananas.sam-mesh.dev` is a free developer testnet created using community resources. It is provided strictly for developer testing and experimentation and carries **no guarantees, uptime commitments, or persistent warranties**. For production workloads or sovereign private meshes, please see the [Kubernetes Deployment Guide](user/kubernetes-deployment.md) and the [Digital & Data Sovereignty Architecture](sovereignty.md).
+> bananas.sam-mesh.dev is a free developer testnet created using community resources. It is provided strictly for developer testing and experimentation and carries **no guarantees, uptime commitments, or persistent warranties**. For production workloads or sovereign private meshes, please see the [Kubernetes Deployment Guide](../user/kubernetes-deployment/) and the [Digital & Data Sovereignty Architecture](../sovereignty/).
 
 ## 1. Install SAM
 

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -6,7 +6,11 @@ weight: 1
 
 # Quick Start
 
-This guide gets you up and running with a SAM node connected to the public `bananas.sam-mesh.dev` mesh. You can run SAM either directly via a binary or using Docker.
+This guide gets you up and running with a SAM node connected to the public `bananas.sam-mesh.dev` developer testnet. You can run SAM either directly via a binary or using Docker.
+
+> [!NOTE]
+> **Developer Testnet Notice:**
+> `bananas.sam-mesh.dev` is a free developer testnet created using community resources. It is provided strictly for developer testing and experimentation and carries **no guarantees, uptime commitments, or persistent warranties**. For production workloads or sovereign private meshes, please see the [Kubernetes Deployment Guide](user/kubernetes-deployment.md) and the [Digital & Data Sovereignty Architecture](sovereignty.md).
 
 ## 1. Install SAM
 

--- a/site/content/docs/sovereignty.md
+++ b/site/content/docs/sovereignty.md
@@ -1,0 +1,139 @@
+---
+title: "Digital & Data Sovereignty"
+linkTitle: "Sovereignty Architecture"
+weight: 12
+---
+
+# Digital & Data Sovereignty in SAM
+
+This document articulates the architecture, technical mechanisms, and legal-regulatory foundations of digital and data sovereignty in the **Sovereign Agent Mesh (SAM)**.
+
+---
+
+## 1. Core Distinctions: OSS Project vs. Products vs. Developer Testnets
+
+To understand sovereignty in SAM, three fundamental distinctions must be established:
+
+### 1.1 An Open-Source Software Project
+SAM is an **open-source software project licensed under Apache-2.0**, developed in the open on [GitHub](https://github.com/google/sam). 
+* It is **an open, decentralized networking protocol and runtime**, not a closed SaaS offering.
+* It contains **no telemetry, no tracking, no phone-home mechanisms**, and no hardcoded dependencies on any proprietary model provider.
+* Operators have the unfettered right to inspect, audit, compile, and deploy the entire software stack on any compute environment worldwide.
+
+### 1.2 Public Developer Testnets Have Zero Sovereign Value
+The public endpoints maintained by project contributors (`bananas.sam-mesh.dev` tracking `main` and `hub.sam-mesh.dev` tracking release tags) are **free, public developer testnets created using community resources**:
+* **Purpose:** They exist strictly as ephemeral testing sandboxes for continuous integration (CI/CD), interoperability checks, and developer rapid prototyping.
+* **Community-Funded with No Guarantees:** Public testnets are hosted using donated community resources and carry **no guarantees, no uptime commitments, and zero SLA**. They hold no production data, provide no persistent storage warranties, and are inherently non-sovereign because you are interacting with a shared developer testing environment. **A shared public testnet is, by definition, not sovereign.**
+
+### 1.3 Sovereignty Through Architectural & Cryptographic Control
+In SAM, digital sovereignty is built on verifiable architectural control: cryptographic key custody, independent identity federation, and strict data residency enforcement. To establish a sovereign deployment, an organization deploys its control plane (`sam-control-plane`), routing layer (`sam-router`), and nodes (`sam-node`) on dedicated infrastructure (such as on-premise datacenters, bare metal, air-gapped environments, or dedicated sovereign cloud infrastructure including Google Cloud with Customer-Managed Keys and regional data residency) using the provided [Helm chart](https://github.com/google/sam/tree/main/charts/sam-mesh) or [Kubernetes deployment guide](../user/kubernetes-deployment/).
+
+---
+
+## 2. Evaluation Against the Five Pillars of Sovereignty
+
+Evaluating SAM in a dedicated sovereign deployment across the five industry-standard pillars of digital sovereignty:
+
+| Pillar | How SAM Delivers Sovereignty | Regulatory & Standards Alignment |
+| :--- | :--- | :--- |
+| **01 · Territorial** | **Cryptographically Attested Egress Gates:** The data plane is direct P2P and end-to-end encrypted (relays carry only ciphertext). Attested label gates (`VerifyPeerLabels`) cryptographically guarantee that prompts, tools, and data never leave defined territorial or jurisdictional boundaries (e.g. `jurisdiction=eu`, `region=de-txl`). | **GDPR Chapter V (Arts. 44–49)** (Cross-border data transfers), **EU Cloud Sovereignty Framework (SEAL-3)** |
+| **02 · Operational** | **Autonomous Key Custody & Local Veto:** The deploying organization generates and holds 100% of the root cryptographic signing keys. Local nodes enforce custom Datalog attenuation policies (`attenuation.checks`, `attenuation.policies`) that execute *before* control plane grants, providing an absolute local veto. | **NIS2 Directive**, **Zero Trust Architecture (NIST SP 800-207)** |
+| **03 · Technological** | **100% Open Source & Uncooperative Sandbox Confinement:** Apache-2.0 license, built on open protocols (libp2p, Biscuit Datalog, MCP, standard OIDC). Agent sandboxes (`sam-box`, `nano-init`) run in `network=none` with structural route isolation, preventing leakage without relying on agent cooperation. | **EU Data Act**, **Open Source Initiative (OSI)** |
+| **04 · Legal / Jurisdictional** | **Autonomous Cryptographic Custody:** By retaining complete custody of root signing keys (via local HSMs, KMS, or Cloud EKM) and identity infrastructure, all cryptographic material and data flows remain under the operator's direct jurisdiction and control, preventing unauthorized extraterritorial access. | **EU Data Protection Law**, **SecNumCloud / C5** |
+| **05 · Financial** | **Zero Lock-In & Open Interoperability:** No license fees, no per-token meters, no proprietary runtime lock-in. Full portability across edge devices, local servers, and multi-cloud environments. | **EU Interoperability Framework (EIF)** |
+
+---
+
+## 3. Concrete Sovereign Acts & Technical Mechanisms
+
+SAM implements specific, verifiable cryptographic and networking mechanisms designed to enforce data and execution sovereignty:
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────────┐
+│ CONSUMER NODE (Local Sovereign Boundary)                                               │
+│                                                                                        │
+│  1. Sandboxed Agent (network=none)                                                     │
+│     └── Issues request: X-Sam-Required-Labels: jurisdiction=eu,compliance=gdpr         │
+│                                                                                        │
+│  2. Local sam-box / sidecar (Fail-Closed Egress Enforcement)                           │
+│     └── Intercepts request before network transmission                                 │
+│     └── Fetches candidate provider's Biscuit token                                     │
+│     └── VerifyPeerLabels(): Cryptographically validates control-plane signature,       │
+│         verifies peer ID binding, and evaluates attested label("jurisdiction", "eu")   │
+│                                                                                        │
+│     [ Verdict: PASS ] ────────────────────────────────────────────────────────┐        │
+└───────────────────────────────────────────────────────────────────────────────┼────────┘
+                                                                                │ P2P e2e
+                                                                                │ encrypted
+┌───────────────────────────────────────────────────────────────────────────────┼────────┐
+│ PROVIDER NODE (Destination Sovereign Boundary)                                ▼        │
+│                                                                                        │
+│  3. Incoming Request Verification                                                      │
+│     └── Authenticates caller Biscuit and token expiration                              │
+│                                                                                        │
+│  4. Local Attenuation Engine (Autonomous Local Veto)                                   │
+│     └── Evaluates local attenuation rules BEFORE control plane grants                  │
+│     └── E.g.: check if label("jurisdiction", "eu");                                    │
+│               deny if client_origin("untrusted_zone");                                 │
+│                                                                                        │
+│  5. Execution in Local Sandbox                                                         │
+└────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 Attested Labels Gate: Territorial & Jurisdictional Containment
+
+In cross-border and multi-tenant agent networks, gossiped metadata cannot be trusted at face value. SAM implements a **fail-closed, cryptographic label gate**:
+1. **Operator-Declared & Authority-Attested:** When a provider node enrolls, its declared labels (e.g. `jurisdiction=eu`, `region=de-west`, `compliance=hipaa`) are verified by the control plane against its role policy and minted into the token authority block as immutable `label(key, value)` Datalog facts (`api.FactLabel`).
+2. **Consumer-Side Verification Before Egress:** When an agent or consumer specifies required labels (via the `X-Sam-Required-Labels` HTTP header or `call_remote_tool` parameters), `VerifyPeerLabels` fetches the provider's Biscuit, verifies the signature against the trusted control plane public key, verifies peer binding, and proves the existence of the required label facts **before any payload byte leaves the local machine**.
+3. **Anti-Exfiltration Guarantee:** If a provider does not present a valid control-plane-signed Biscuit attesting to the required jurisdiction or security label, the connection is aborted immediately. Gossiped DHT records are only used for discovery ranking; they are never trusted for authorization.
+
+### 3.2 Autonomous Local Veto: Destination-Side Attenuation
+
+Under Zero Trust and operational sovereignty, a centralized control plane must never possess absolute power over local compute and data. 
+* Local nodes configure an `attenuation` block containing local Datalog rules and policies.
+* **Evaluation Order:** Local policies are evaluated **before** central control plane grants. Even if a central authority grants a remote agent access to a service (e.g. `mcp://*`), the destination node operator can unilaterally veto or restrict access using local rules:
+
+```yaml
+# Local node attenuation configuration (sam-node.yaml)
+attenuation:
+  rules:
+    - 'time(2026-09-01T00:00:00Z) <- true;'
+  policies:
+    # Autonomous local veto: reject any caller not attested in the EU jurisdiction
+    - 'deny if !label("jurisdiction", "eu");'
+    - 'deny if user("revoked_contractor_id");'
+```
+
+### 3.3 Identity Evidence API: Independent Auditing Without Phone-Home
+
+To comply with regulatory audit requirements (e.g., EU Cloud Sovereignty Framework SEAL-3, ISO 27001, SOC2), nodes expose local, cryptographically sealed evidence endpoints (`GET /sam/identity` and `GET /sam/peer/{peer_id}/evidence`):
+* Allows auditors and local verification engines to inspect raw Biscuit tokens, SPKI DER public key certificates, role assignments, and attested labels.
+* **Offline Verification:** Verification is mathematically self-contained using public-key cryptography; no live network calls or telemetry to external servers are required.
+
+---
+
+## 4. Addressing Zero-Trust Invariants vs. "Kill Switch" Misconceptions
+
+In discussions of cryptographic networks, bounded credentials and revocation mechanisms are occasionally misunderstood. It is vital to clarify the cryptographic purpose of these invariants:
+
+### 4.1 Bounded Token Expiration (TTL)
+* **Cryptographic Rationale:** In Zero-Trust architectures, bearer credentials must have finite lifetimes (e.g. 24 hours). This mitigates the risk of replay attacks, stolen token persistence, and long-term key compromise. This is the same principle underlying **SPIFFE/SPIRE SVID rotation**, **OAuth 2.0 access token TTLs**, and **Kerberos ticket lifetimes**.
+* **Operator Control:** In a dedicated sovereign control plane, the token lifetime, renewal interval, and grace periods are fully configured by the local administrator.
+* **Fail-Closed Principle:** When a cryptographic credential expires and cannot be renewed (for instance, if the node has been decommissioned or network partitioned), the node daemon terminates its active mesh routes to prevent unauthorized, unauthenticated state persistence.
+
+### 4.2 Cryptographic Revocation
+* **Security Function:** Revocation (`/admin/revoke`) allows network administrators to instantly ban a compromised node or rogue agent from the mesh.
+* **Sovereign Authority:** In a dedicated deployment, the revocation authority belongs exclusively to the organization deploying the control plane. Nobody outside that organization possesses root keys or revocation privileges.
+
+---
+
+## 5. Summary: The Sovereign Architecture Checklist
+
+When deploying SAM for mission-critical, sovereign agent operations:
+
+1. **Deploy Dedicated Control Plane Infrastructure:** Use the Helm chart or Kubernetes manifests to launch `sam-control-plane` on your chosen sovereign infrastructure (managed cloud with customer keys, private Kubernetes, or bare metal).
+2. **Maintain Root Cryptographic Key Custody:** Generate, manage, and hold your own Ed25519 root signing keys (via KMS/Cloud EKM or HSMs).
+3. **Use Your Own OIDC Identity Provider:** Point `--issuer` to your internal Keycloak, Dex, or corporate IdP.
+4. **Declare & Attest Sovereignty Labels:** Run nodes with `--labels jurisdiction=eu,region=<your-region>` and configure control plane roles with `allowed_labels`.
+5. **Enforce Jurisdictional Egress:** Direct agents to specify `X-Sam-Required-Labels: jurisdiction=eu` on all inference and MCP requests to guarantee zero data leakage beyond authorized perimeters.
+6. **Set Local Attenuation Vetoes:** Configure local node `attenuation.policies` to retain final destination-side access control.

--- a/site/content/docs/user/node-configuration.md
+++ b/site/content/docs/user/node-configuration.md
@@ -124,5 +124,7 @@ Because every enrolled node's token carries its attested label facts, a provider
 attenuation:
   checks:
     - 'check if label("region", "us-east-1");'
+    - 'check if label("jurisdiction", "eu");'
 ```
 
+For full details on territorial enforcement, regulatory compliance (GDPR Art 44-49, EU Cloud Sovereignty Framework), and cryptographic evidence verification, see the **[Digital & Data Sovereignty Guide](../sovereignty/)**.

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -67,7 +67,6 @@ sectionPagesMenu = "main"
     weight = 5
 
 [params]
-  privacy_policy = "https://policies.google.com/privacy"
   github_repo = "https://github.com/google/sam"
   github_subdir = "docs"
   github_branch = "main"
@@ -79,7 +78,3 @@ sectionPagesMenu = "main"
     ul_show = 1
 
   # Logo & branding colors will be customized via project styles
-
-[services]
-  [services.googleAnalytics]
-    id = "G-F9G8NX0SBT"


### PR DESCRIPTION
### Summary

This PR clarifies the documentation regarding digital and data sovereignty, refines the scope and expectations of community-hosted developer testnets, and cleans up site template scaffolding.

### Key Changes
1. **Digital & Data Sovereignty Architecture (`docs/sovereignty.md`):**
   - Documents SAM's sovereignty model across the 5 pillars (Territorial, Operational, Technological, Legal/Jurisdictional, Financial).
   - Details concrete technical mechanisms: cryptographic label gating (`VerifyPeerLabels`), local attenuation vetoes (`attenuation.policies`), uncooperative sandbox isolation (`sam-box`), and offline Identity Evidence APIs (`/sam/identity`).
   - Aligns terminology with customer ownership, governance, and cryptographic key custody standards (EU Data Act, GDPR Chapter V, EU Cloud Sovereignty Framework SEAL-3).
2. **Developer Testnet Clarification:**
   - Explicitly scopes `bananas.sam-mesh.dev` and `hub.sam-mesh.dev` as community-resourced developer testbeds with no SLA or sovereign properties.
   - Clarifies that sovereign deployments require running a dedicated control plane with customer-managed cryptographic keys.
3. **Site & Asset Hygiene (`site/hugo.toml`):**
   - Removed upstream Docsy theme template scaffolding to ensure the documentation website matches the project's zero-telemetry posture.
   