### PR TITLE
ci: cut the mobile e2e critical path with caches and phase separation

### DIFF
--- a/.github/workflows/test_flutter.yaml
+++ b/.github/workflows/test_flutter.yaml
@@ -25,6 +25,11 @@ on:
 permissions:
   contents: read
 
+# A superseded push to the same PR obsoletes the running check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   GO_VERSION: "1.26"
 
@@ -32,13 +37,12 @@ jobs:
   build-ffi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        cache: false
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
     - run: make mobile-ffi-host
 
   analyze-flutter:
@@ -50,6 +54,7 @@ jobs:
     - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
       with:
         channel: 'stable'
+        cache: true
     - name: Install dependencies
       run: flutter pub get
       working-directory: mobile/sam-node-app
@@ -66,15 +71,16 @@ jobs:
     - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
-        cache: false
     - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
       with:
         channel: 'stable'
+        cache: true
     - name: Set up JDK
       uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         java-version: '17'
         distribution: 'temurin'
+        cache: 'gradle'
     - name: Enable KVM group perms
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -91,14 +97,37 @@ jobs:
           echo "[CI] GOOGLE_SERVICES_JSON_BASE64 secret not set, copying dummy configuration template..."
           cp mobile/sam-node-app/android/app/google-services.json.tmpl mobile/sam-node-app/android/app/google-services.json
         fi
+    - name: Build images and start the mesh (no emulator needed)
+      run: ./mobile/mobile_e2e.sh setup
+    - name: AVD cache
+      id: avd-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-30-google_apis-x86_64
+    - name: Create AVD snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+      with:
+        api-level: 30
+        target: google_apis
+        arch: x86_64
+        force-avd-creation: false
+        disable-animations: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        emulator-boot-timeout: 300
+        script: echo "Generated AVD snapshot for caching."
     - name: Run E2E Integration Test in Android Emulator
       uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
       with:
         api-level: 30
         target: google_apis
         arch: x86_64
+        force-avd-creation: false
         disable-animations: true
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         emulator-boot-timeout: 300
-        script: ./mobile/mobile_e2e.sh
+        script: ./mobile/mobile_e2e.sh test
 

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ docker-build-router:
 	docker build --load -t sam-router:local -f Dockerfile.sam-router .
 
 docker-build-node:
-	docker build --load --no-cache -t sam-node:local -f Dockerfile.sam-node .
+	docker build --load -t sam-node:local -f Dockerfile.sam-node .
 
 docker-build-mock-oidc:
 	docker build --load -t sam-mock-oidc:local -f tests/e2e/docker/Dockerfile.mock-oidc .

--- a/mobile/mobile_e2e.sh
+++ b/mobile/mobile_e2e.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -xeuo pipefail
+set -xeEuo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." &> /dev/null && pwd)
@@ -36,16 +36,31 @@ cleanup() {
   rm -rf /tmp/host-node-data /tmp/control-plane-data /tmp/router-data
   adb reverse --remove-all || true
 }
-trap cleanup EXIT
 
-# 1. Build host binaries and docker images
-make build
-make docker-build-control-plane docker-build-router docker-build-node docker-build-mock-oidc
+# Phases let CI build and start the mesh before the emulator exists (setup),
+# and run only the device-attached part under the emulator (test). Locally,
+# the default runs both against an already-connected device.
+PHASE="${1:-all}"
+case "$PHASE" in
+  setup) trap cleanup ERR ;; # on success the mesh stays up for the test phase
+  test | all) trap cleanup EXIT ;;
+  *)
+    echo "usage: $0 [setup|test|all]" >&2
+    exit 2
+    ;;
+esac
 
-# 2. Build Android x86_64 FFI library using the Makefile and copy to Flutter jniLibs
-make mobile-ffi-android-x86_64
+setup_env() {
+# 1. Build the host mcp-client (the only host binary the test drives), the
+# docker images and the Android FFI library in one parallel make run.
+go build -v -o "$REPO_ROOT/bin/mcp-client" ./cmd/mcp-client
+make -j4 docker-build-control-plane docker-build-router docker-build-node docker-build-mock-oidc mobile-ffi-android-x86_64
 mkdir -p mobile/sam-node-app/android/app/src/main/jniLibs/x86_64
 cp bin/android-x86_64/libsam.so mobile/sam-node-app/android/app/src/main/jniLibs/x86_64/libsam.so
+
+# Warm the app dependencies so the emulator-attached phase goes straight to
+# the gradle build.
+(cd mobile/sam-node-app && flutter pub get)
 
 # Create Docker bridge network
 docker network create sam-net || true
@@ -59,9 +74,6 @@ docker run --name mock-oidc \
 
 # Wait for OIDC server to be ready
 timeout 15s bash -c 'until curl -s http://127.0.0.1:18080/ >/dev/null; do sleep 0.5; done'
-
-# Set up adb reverse for OIDC
-adb reverse tcp:18080 tcp:18080
 
 # 4. Start the Control Plane and Router containers
 rm -rf /tmp/control-plane-data /tmp/router-data
@@ -102,10 +114,6 @@ docker run --name sam-router \
   --keys-path /data/router.key \
   --allow-loopback \
   --log-level debug
-
-# Set up adb reverse for Control Plane and Router
-adb reverse tcp:37001 tcp:37001
-adb reverse tcp:37002 tcp:37002
 
 # Wait for Control Plane to be ready
 timeout 15s bash -c 'until curl -s http://127.0.0.1:37001/info >/dev/null; do sleep 0.5; done'
@@ -243,10 +251,17 @@ curl -s -X POST \
   -H "Authorization: Bearer host-token" \
   -d '{"service":{"type":"SERVICE_TYPE_MCP","name":"host-tool","description":"test tool on host"},"targetUrl":"http://host-mock-mcp:9091"}' \
   http://127.0.0.1:8081/sam/service/register
+}
 
-# 7. Start the Android Emulator and run the Flutter integration test
-# Since this script runs on CI inside ReactiveCircus/android-emulator-runner,
-# the emulator is already started and adb is fully connected to the emulator.
+run_test() {
+# The emulator reaches the host mesh through adb reverse.
+adb reverse tcp:18080 tcp:18080
+adb reverse tcp:37001 tcp:37001
+adb reverse tcp:37002 tcp:37002
+
+# 7. Run the Flutter integration test against the running emulator.
+# On CI this phase runs inside ReactiveCircus/android-emulator-runner,
+# so the emulator is already started and adb is fully connected to it.
 cd mobile/sam-node-app
 
 # Run Flutter integration test
@@ -309,3 +324,13 @@ fi
 
 echo "[E2E] SUCCESS: Bidirectional mobile E2E test passed!"
 exit 0
+}
+
+case "$PHASE" in
+  setup) setup_env ;;
+  test) run_test ;;
+  all)
+    setup_env
+    run_test
+    ;;
+esac


### PR DESCRIPTION
The `e2e-android` job ran everything cold and everything serial, most of it while holding the booted emulator:

- Go module/build caches were explicitly disabled (`cache: false`), so `make build` recompiled the world every run — for eight host binaries when the script only drives `bin/mcp-client`.
- Four docker images built sequentially, then the NDK cross-compile.
- The emulator system image was re-downloaded and cold-booted every run (5 min budget).
- Gradle and the Flutter SDK were re-fetched every run.
- `docker-build-node` carried a `--no-cache` that defeated layer caching for every caller.

### Changes

- `mobile/mobile_e2e.sh` now has phases: **`setup`** builds the images (one parallel `make -j4`, including the FFI cross-compile) and starts the mesh *before any emulator exists*; **`test`** is only the device-attached part (adb reverse + `flutter test` + verification); the default **`all`** keeps the local single-shot flow unchanged.
- The workflow runs `setup` as a plain step and holds the emulator only for the `test` phase.
- AVD snapshot caching (ReactiveCircus documented pattern): warm runs boot from snapshot instead of re-downloading and cold-booting the system image.
- Go, Gradle and Flutter SDK caches enabled (also in `build-ffi`/`analyze-flutter`); `flutter pub get` warmed during setup.
- `concurrency` with `cancel-in-progress` for PRs, so superseded pushes stop occupying runners.

First run on this PR is cold (it populates the caches); the second run should show the real effect. Validated locally: `bash -n`, YAML parse, and the unchanged `all` flow still drives the same commands in the same order.