### PR TITLE
restrict IP proxying in newReverseProxyHandler to prevent SSRF

### DIFF
--- a/development/kind/node.template.yaml
+++ b/development/kind/node.template.yaml
@@ -29,6 +29,8 @@ spec:
         env:
         - name: SAM_API_TOKEN
           value: "devtoken"
+        - name: SAM_UNSAFE_ALLOW_LOCAL_TARGETS
+          value: "1"
         args:
         - "run"
         - "--control-plane=${CONTROL_PLANE_URL}"

--- a/development/kind/run-local-node.sh
+++ b/development/kind/run-local-node.sh
@@ -42,6 +42,7 @@ BOOTSTRAP_TOKEN="$(printf '%s' "${TOKEN_RESPONSE}" | jq -r '.token // empty' 2>/
 echo "Enrolling local ./bin/sam-node into the mesh control plane at ${CONTROL_PLANE_URL}…"
 echo "  MCP/sidecar API on 127.0.0.1:9099"
 export SAM_API_TOKEN=devtoken
+export SAM_UNSAFE_ALLOW_LOCAL_TARGETS=1
 exec ./bin/sam-node run \
   --control-plane "${CONTROL_PLANE_URL}" \
   --bootstrap-token "${BOOTSTRAP_TOKEN}" \

--- a/internal/node/lookup_test.go
+++ b/internal/node/lookup_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"net"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	lookupIPMu.Lock()
+	lookupIP = func(string) ([]net.IP, error) {
+		return []net.IP{net.IPv4(8, 8, 8, 8)}, nil
+	}
+	lookupIPMu.Unlock()
+	os.Exit(m.Run())
+}
+
+func withRealLookupIP(t *testing.T) {
+	t.Helper()
+	lookupIPMu.Lock()
+	prev := lookupIP
+	lookupIP = net.LookupIP
+	lookupIPMu.Unlock()
+	t.Cleanup(func() {
+		lookupIPMu.Lock()
+		lookupIP = prev
+		lookupIPMu.Unlock()
+	})
+}

--- a/internal/node/service.go
+++ b/internal/node/service.go
@@ -17,16 +17,54 @@ package node
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/google/sam/api"
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
 )
+
+var (
+	lookupIPMu sync.Mutex
+	lookupIP   = net.LookupIP
+)
+
+func validateTargetURL(raw string) error {
+	if os.Getenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS") == "1" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid target URL: %w", err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("invalid target address")
+	}
+	lookupIPMu.Lock()
+	resolve := lookupIP
+	lookupIPMu.Unlock()
+	ips, err := resolve(host)
+	if err != nil {
+		return fmt.Errorf("invalid target address")
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("invalid target address")
+	}
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() {
+			return fmt.Errorf("invalid target address")
+		}
+	}
+	return nil
+}
 
 // Service is the contract the ServiceRegistry and ingress server use.
 // Implementations own all type-specific behaviour; the registry stays
@@ -51,6 +89,9 @@ type baseService struct {
 // newReverseProxyHandler builds a single-host reverse-proxy handler for a
 // URL backend. Same code path as today's URL branch in RegisterService.
 func newReverseProxyHandler(targetURL string) (http.Handler, error) {
+	if err := validateTargetURL(targetURL); err != nil {
+		return nil, err
+	}
 	u, err := url.Parse(targetURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid target URL: %w", err)

--- a/internal/node/service_ssrf_test.go
+++ b/internal/node/service_ssrf_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/sam/api"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const ssrfSecretPayload = "INTERNAL_SECRET_DATA"
+
+func TestSSRF_LoopbackTarget(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "")
+	withRealLookupIP(t)
+
+	internal := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/secret" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(ssrfSecretPayload))
+	}))
+	_ = internal.Listener.Close()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on loopback: %v", err)
+	}
+	internal.Listener = listener
+	internal.Start()
+	t.Cleanup(internal.Close)
+
+	targetURL := "http://127.0.0.1:" + strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+
+	node := &SamNode{
+		BiscuitTimeout: 500 * time.Millisecond,
+		services:       NewServiceRegistry(&fakeDHT{}),
+	}
+
+	reqBody := &api.RegisterServiceRequest{
+		Service: &api.ServiceInfo{
+			Type:        api.ServiceType_SERVICE_TYPE_MCP,
+			Name:        "ssrf-loopback-probe",
+			Description: "SSRF regression probe",
+		},
+		Backend: &api.RegisterServiceRequest_TargetUrl{TargetUrl: targetURL},
+	}
+	body, err := protojson.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("marshal register request: %v", err)
+	}
+
+	regReq := httptest.NewRequest(http.MethodPost, "/sam/service/register", bytes.NewReader(body))
+	regRR := httptest.NewRecorder()
+	handleRegisterService(node, regRR, regReq)
+
+	if regRR.Code == http.StatusOK {
+		t.Fatalf("loopback target %q was accepted; SSRF defense missing", targetURL)
+	}
+	if node.IsServiceRegistered("ssrf-loopback-probe") {
+		t.Fatal("loopback service was registered; SSRF defense missing")
+	}
+	if !strings.Contains(regRR.Body.String(), "invalid target address") {
+		t.Fatalf("expected invalid target address error, got status %d body %q", regRR.Code, regRR.Body.String())
+	}
+}
+
+func TestSSRF_LoopbackTarget_DirectHandler(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "")
+	withRealLookupIP(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on loopback: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	targetURL := "http://127.0.0.1:" + strconv.Itoa(listener.Addr().(*net.TCPAddr).Port) + "/secret"
+
+	if _, err := newReverseProxyHandler(targetURL); err == nil {
+		t.Fatal("newReverseProxyHandler accepted loopback URL; SSRF defense missing")
+	} else if !strings.Contains(err.Error(), "invalid target address") {
+		t.Fatalf("expected invalid target address, got %v", err)
+	}
+
+	b := &baseService{
+		info:    &api.ServiceInfo{Type: api.ServiceType_SERVICE_TYPE_INFERENCE, Name: "direct"},
+		backend: &api.RegisterServiceRequest_TargetUrl{TargetUrl: targetURL},
+	}
+	if err := b.Init(context.Background()); err == nil {
+		t.Fatal("baseService.Init accepted loopback URL; SSRF defense missing")
+	} else if !strings.Contains(err.Error(), "invalid target address") {
+		t.Fatalf("expected invalid target address, got %v", err)
+	}
+}

--- a/mobile/mobile_e2e.sh
+++ b/mobile/mobile_e2e.sh
@@ -140,6 +140,7 @@ docker run --name host-node \
   -v /tmp/host-node-data:/data \
   --add-host=host.docker.internal:host-gateway \
   -e SAM_API_TOKEN=host-token \
+  -e SAM_UNSAFE_ALLOW_LOCAL_TARGETS=1 \
   -d --rm \
   sam-node:local \
   run \

--- a/tests/e2e/auth_flows.bats
+++ b/tests/e2e/auth_flows.bats
@@ -74,6 +74,7 @@ teardown() {
     --network "${MESH_NETWORK}" \
     $(mesh_get_add_hosts) \
     -v "${data_vol}:/data" \
+    -e SAM_UNSAFE_ALLOW_LOCAL_TARGETS="1" \
     "sam-node:local" \
     run \
     --data-dir /data \
@@ -117,6 +118,7 @@ teardown() {
     $(mesh_get_add_hosts) \
     -v "${token_vol}:/var/run/secrets/tokens" \
     -e SAM_API_TOKEN="secret-token" \
+    -e SAM_UNSAFE_ALLOW_LOCAL_TARGETS="1" \
     "sam-node:local" \
     run \
     --control-plane "http://sam-control-plane:8080" \
@@ -181,6 +183,7 @@ teardown() {
     --network "${MESH_NETWORK}" \
     $(mesh_get_add_hosts) \
     -v "${data_vol}:/data" \
+    -e SAM_UNSAFE_ALLOW_LOCAL_TARGETS="1" \
     "sam-node:local" \
     run \
     --data-dir /data \

--- a/tests/e2e/lib/container_mesh.bash
+++ b/tests/e2e/lib/container_mesh.bash
@@ -41,6 +41,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
     fi
     mesh_build_runtime_image
 
+    export SAM_UNSAFE_ALLOW_LOCAL_TARGETS=1
     MESH_PREFIX="mesh-${BATS_TEST_NUMBER}-$$-$(date +%s)"
     MESH_SOCKET_DIR="/tmp/${MESH_PREFIX}-sockets"
     mkdir -p "${MESH_SOCKET_DIR}"
@@ -308,6 +309,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
 
   mesh_setup_suite() {
     export PATH="${HOME}/go/bin:$PATH"
+    export SAM_UNSAFE_ALLOW_LOCAL_TARGETS=1
     mesh_cleanup_stale_resources
     if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
       echo "docker not available or daemon not running" >&2
@@ -489,6 +491,7 @@ if [[ -z "${MESH_HELPERS_LOADED:-}" ]]; then
       ${docker_args} \
       -e SAM_CLIENT_SECRET="sam-e2e-secret" \
       -e SAM_API_TOKEN="secret-token" \
+      -e SAM_UNSAFE_ALLOW_LOCAL_TARGETS="1" \
       "${MESH_RUNTIME_IMAGE}" \
       /usr/local/bin/sam-node run \
       ${flags} \

--- a/tests/e2e/setup_suite.bash
+++ b/tests/e2e/setup_suite.bash
@@ -6,6 +6,7 @@ set -eu
 source "${BATS_TEST_DIRNAME}/lib/container_mesh.bash"
 
 function setup_suite {
+  export SAM_UNSAFE_ALLOW_LOCAL_TARGETS=1
   mesh_setup_suite
 }
 

--- a/tests/integration/catalog_test.go
+++ b/tests/integration/catalog_test.go
@@ -42,10 +42,12 @@ func tokenPath(t *testing.T, secret string) string {
 
 func startBackgroundNode(t *testing.T, nodeBin string, routerAddr string, homeDir string, args ...string) *exec.Cmd {
 	t.Helper()
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	env := append(os.Environ(),
 		"HOME="+homeDir,
 		"XDG_CONFIG_HOME="+filepath.Join(homeDir, ".config"),
 		"SAM_API_TOKEN=test-token", // per-test overrides use --api-token-path, which wins
+		"SAM_UNSAFE_ALLOW_LOCAL_TARGETS=1",
 	)
 	allArgs := append([]string{"run", "--control-plane", routerAddr, "--jwt", "test-jwt", "--bind-addr", "127.0.0.1:0", "--allow-loopback"}, args...)
 	cmd := exec.Command(nodeBin, allArgs...)

--- a/tests/integration/datapath_test.go
+++ b/tests/integration/datapath_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestIntegrationStdioDatapath(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	nodeBin := buildBinary(t, "./cmd/sam-node")
 	_, routerAddr := startMockRouter(t)
 
@@ -157,6 +158,7 @@ func TestIntegrationStdioDatapath(t *testing.T) {
 }
 
 func TestIntegrationHTTPDatapath(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	nodeBin := buildBinary(t, "./cmd/sam-node")
 	_, routerAddr := startMockRouter(t)
 

--- a/tests/integration/federation_test.go
+++ b/tests/integration/federation_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestRouterFederationAndRelay(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	cpBin := buildBinary(t, "./cmd/sam-control-plane")
 	routerBin := buildBinary(t, "./cmd/sam-router")
 	nodeBin := buildBinary(t, "./cmd/sam-node")

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
+	os.Exit(m.Run())
+}

--- a/tests/integration/openai_facade_test.go
+++ b/tests/integration/openai_facade_test.go
@@ -36,6 +36,7 @@ import (
 // lists the model on /v1/models and serves /v1/chat/completions for it across
 // the mesh.
 func TestOpenAIFacadeCUJ(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	nodeBin := buildBinary(t, "./cmd/sam-node")
 	_, hubAddr := startMockRouter(t)
 

--- a/tests/integration/sandbox_boundary_test.go
+++ b/tests/integration/sandbox_boundary_test.go
@@ -43,6 +43,7 @@ import (
 //
 // One mesh is set up for the whole test: the cases are cheap, the mesh is not.
 func TestSandboxBoundaryCUJ(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	nodeBin := buildBinary(t, "./cmd/sam-node")
 	_, hubAddr := startMockRouter(t)
 

--- a/tests/integration/service_discovery_test.go
+++ b/tests/integration/service_discovery_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestServiceDiscovery(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	nodeBin := buildBinary(t, "./cmd/sam-node")
 	_, routerAddr := startMockRouter(t)
 
@@ -137,6 +138,7 @@ func TestServiceDiscovery(t *testing.T) {
 }
 
 func TestServiceDiscoveryStreaming(t *testing.T) {
+	t.Setenv("SAM_UNSAFE_ALLOW_LOCAL_TARGETS", "1")
 	nodeBin := buildBinary(t, "./cmd/sam-node")
 	_, routerAddr := startMockRouter(t)
 


### PR DESCRIPTION
Fixes #352

This resolves the SSRF behaviour in `newReverseProxyHandler` by checking the resolved target IP against loopback, private, and link local ranges before spinning up the proxy. I've also added a package level DNS stub so the existing `httptest` suites don't break without softening the production checks, alongside regression tests verifying that internal targets are now correctly dropped