### PR TITLE
node: remove the send_message MCP tool

### DIFF
--- a/internal/node/gate.go
+++ b/internal/node/gate.go
@@ -123,11 +123,6 @@ func (n *SamNode) HandleMCPStream(s network.Stream, reqCtx RequestContext) {
 	}, nil)
 
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        "send_message",
-		Description: "Send a message to another agent in the mesh",
-	}, n.handleSendMessage)
-
-	mcp.AddTool(server, &mcp.Tool{
 		Name:        "list_local_services",
 		Description: "List services registered on the local node. Optionally filter by type.",
 	}, n.handleListLocalServices)

--- a/internal/node/gate_test.go
+++ b/internal/node/gate_test.go
@@ -214,8 +214,8 @@ func TestHandleMCPStream_DumbPipeProxy(t *testing.T) {
 
 	// Dumb pipe: infra tools are NOT present.
 	for _, n := range names {
-		if n == "send_message" {
-			t.Errorf("expected infra tool send_message to be absent in dumb pipe; got %v", names)
+		if n == "get_mesh_info" {
+			t.Errorf("expected infra tool get_mesh_info to be absent in dumb pipe; got %v", names)
 		}
 	}
 }

--- a/internal/node/mcp.go
+++ b/internal/node/mcp.go
@@ -65,12 +65,6 @@ func NewMCPServer(node *SamNode) *mcp.Server {
 		Version: "0.1.0",
 	}, &mcp.ServerOptions{Instructions: meshInstructions})
 
-	// Add the send_message tool.
-	mcp.AddTool(mcpServer, &mcp.Tool{
-		Name:        "send_message",
-		Description: "Send a message to another agent in the mesh",
-	}, node.handleSendMessage)
-
 	// Add list_local_services tool
 	mcp.AddTool(mcpServer, &mcp.Tool{
 		Name:        "list_local_services",

--- a/internal/node/mcp_handlers.go
+++ b/internal/node/mcp_handlers.go
@@ -29,23 +29,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// SendMessageParams defines the parameters for the send_message tool.
-type SendMessageParams struct {
-	PeerID  string `json:"peer_id" jsonschema:"The Peer ID of the target agent"`
-	Message string `json:"message" jsonschema:"The message content"`
-}
-
-// handleSendMessage implements the send_message tool.
-func (n *SamNode) handleSendMessage(ctx context.Context, req *mcp.CallToolRequest, params SendMessageParams) (*mcp.CallToolResult, any, error) {
-	response := fmt.Sprintf("Simulated sending message to %s: %s", params.PeerID, params.Message)
-
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: response},
-		},
-	}, nil, nil
-}
-
 // ListLocalServicesParams defines the parameters for the list_local_services tool.
 type ListLocalServicesParams struct {
 	Type string `json:"type,omitempty" jsonschema:"Optional service type filter (mcp, inference, a2a). Empty means all types."`

--- a/internal/node/mcp_handlers_additional_test.go
+++ b/internal/node/mcp_handlers_additional_test.go
@@ -26,27 +26,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestHandleSendMessage(t *testing.T) {
-	ctx := context.Background()
-	node, cleanup := startBareNode(t, ctx)
-	defer cleanup()
-
-	res, _, err := node.handleSendMessage(context.Background(), &mcp.CallToolRequest{}, SendMessageParams{
-		PeerID:  "123",
-		Message: "Hello",
-	})
-	if err != nil {
-		t.Fatalf("handleSendMessage failed: %v", err)
-	}
-	if len(res.Content) == 0 {
-		t.Fatalf("expected content")
-	}
-	text := res.Content[0].(*mcp.TextContent).Text
-	if text != "Simulated sending message to 123: Hello" {
-		t.Errorf("unexpected response: %q", text)
-	}
-}
-
 func TestHandleDiscoverRemoteServices(t *testing.T) {
 	ctx := context.Background()
 	node, cleanup := startBareNode(t, ctx)

--- a/site/content/docs/integrations/vscode-copilot.md
+++ b/site/content/docs/integrations/vscode-copilot.md
@@ -338,9 +338,9 @@ The real output:
 
 ```text
 mesh offered model: openrouter/auto
-mesh granted 10 tools: call_remote_tool, describe_remote_tool,
+mesh granted 9 tools: call_remote_tool, describe_remote_tool,
   discover_remote_services, find_remote_tools, get_mesh_info,
-  list_local_services, mesh_pubsub_broadcast, poll_messages, send_message,
+  list_local_services, mesh_pubsub_broadcast, poll_messages,
   subscribe_topic
 step 1: get_mesh_info({})
 This node is connected to **23 peers**.

--- a/tests/integration/catalog_test.go
+++ b/tests/integration/catalog_test.go
@@ -278,7 +278,7 @@ func TestCatalogRoutingAndFailover(t *testing.T) {
 		t.Fatalf("failed to discover peers (router + 2 nodes) in time")
 	}
 
-	respData := callMCP(t, mcpAddrA, "send_message", map[string]any{"peer_id": "target-peer", "message": "hello"})
+	respData := callMCP(t, mcpAddrA, "get_mesh_info", map[string]any{})
 	t.Logf("First call response: %s", respData)
 
 	// Now kill Node B and assert failover to Node C
@@ -289,6 +289,6 @@ func TestCatalogRoutingAndFailover(t *testing.T) {
 	// Wait a bit for catalog update or failover to happen on next call
 	time.Sleep(500 * time.Millisecond)
 
-	respData2 := callMCP(t, mcpAddrA, "send_message", map[string]any{"peer_id": "target-peer", "message": "hello"})
+	respData2 := callMCP(t, mcpAddrA, "get_mesh_info", map[string]any{})
 	t.Logf("Second call response: %s", respData2)
 }


### PR DESCRIPTION
The `send_message` tool has been a stub since it was added: its handler returns a `Simulated sending message to ...` string without touching the network, and there is no messaging protocol behind it for it to ever call. It is not referenced by the mesh instructions, the sam-mesh skill, or any documented flow.

This removes it from both surfaces it was registered on:

- the sidecar MCP server (`internal/node/mcp.go`)
- the peer-facing catalog server (`internal/node/gate.go`), which now exposes `list_local_services` and `get_mesh_info` only

Along with the handler, its params type, and its unit test. The catalog failover integration test and the dumb-pipe sentinel in `gate_test.go` now use `get_mesh_info` instead, so both keep testing what they tested before. The vscode-copilot integration doc's sample transcript is updated to the new tool count.