### PR TITLE
deploy: define sam:role:node in the seeded policy and fail loudly on …

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -391,7 +391,7 @@ jobs:
             sleep 1
           done
           
-          curl -s -X POST \
+          curl -fsS -X POST \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${ADMIN_TOKEN}" \
             -d '{
@@ -399,6 +399,7 @@ jobs:
                 {"name": "sam-canary", "allowed_services": ["*"], "allowed_targets": ["*"]},
                 {"name": "sam:role:sambox", "allowed_services": ["*"], "allowed_targets": ["*"]},
                 {"name": "sam:role:router", "allowed_services": ["*"], "allowed_targets": ["*"]},
+                {"name": "sam:role:node"},
                 {"name": "public-mesh", "allowed_services": ["*"], "allowed_targets": ["*"]}
               ],
               "bindings": [
@@ -408,7 +409,11 @@ jobs:
                 {"role": "public-mesh", "members": ["sam:system:authenticated"]}
               ]
             }' \
-            http://localhost:8080/policies >/dev/null
+            http://localhost:8080/policies || {
+            echo "Policy seeding failed - a rejected policy leaves enrollment broken (nodes get 403 at /register)."
+            kill $PF_PID
+            exit 1
+          }
             
           kill $PF_PID
 


### PR DESCRIPTION
…rejection

The policy seed bound sam:role:node without defining the role, and /policies validation (strict since the GHSA-cgmg fixes) rejects bindings to undefined roles - but the seeding curl was -s with no -f, so the 400 vanished, the stale policy stayed, and every canary node got 403 'requested role is not bound to this identity' at /register. Reproduced and fixed against the live bananas control plane; the role carries no grants of its own (access still comes from public-mesh), it is purely the explicit open-enrollment seat. curl -fsS now aborts the deploy with a message naming the consequence.