### PR TITLE
deploy: on-demand sam-one Cloud Run sandbox workflow

### DIFF
--- a/.github/workflows/deploy-sam-one.yaml
+++ b/.github/workflows/deploy-sam-one.yaml
@@ -1,0 +1,204 @@
+name: Sam-One Cloud Run Sandbox
+
+# On-demand sam-one deployments on Cloud Run (see
+# site/content/docs/user/cloud-run-deployment.md for the manual version).
+# Deploys are gated by the 'sam-one-sandbox' GitHub Environment: required
+# reviewers approve each run before GCP credentials are minted.
+#
+# Generated join/admin tokens never appear in logs: they are encrypted to
+# the SSH public keys of the user who triggered the run (github.com/<user>.keys)
+# and published in the job summary as an age-armored blob.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'What to do'
+        type: choice
+        options: [deploy, delete]
+        default: deploy
+      name:
+        description: 'Sandbox name (service becomes sam-one-<name>)'
+        type: string
+        default: sandbox
+      region:
+        description: 'Cloud Run region'
+        type: choice
+        options: [us-central1, europe-west1, asia-northeast1]
+        default: us-central1
+
+run-name: 'sam-one ${{ inputs.action }} ${{ inputs.name }} @ ${{ inputs.region }} (${{ github.ref_name }}) by ${{ github.actor }}'
+
+# One run at a time per sandbox; never cancel an in-flight deploy.
+concurrency:
+  group: sam-one-${{ inputs.name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  sandbox:
+    name: '${{ inputs.action }} sam-one-${{ inputs.name }}'
+    runs-on: ubuntu-latest
+    environment: sam-one-sandbox
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      REGION: ${{ inputs.region }}
+      SERVICE: sam-one-${{ inputs.name }}
+      AR_REPO: ${{ vars.AR_REPO || 'sam-mesh' }}
+      # The sam-mesh AR repo only exists in us-central1; Cloud Run pulls
+      # cross-region, so the deploy region stays a free choice.
+      AR_LOCATION: ${{ vars.AR_LOCATION || 'us-central1' }}
+
+    steps:
+      - name: Validate inputs
+        env:
+          INPUT_NAME: ${{ inputs.name }}
+        run: |
+          if ! [[ "${INPUT_NAME}" =~ ^[a-z][a-z0-9-]{0,29}$ ]]; then
+            echo "::error::name must match ^[a-z][a-z0-9-]{0,29}$ (got '${INPUT_NAME}')"
+            exit 1
+          fi
+
+      - name: Check out code
+        if: inputs.action == 'deploy'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Google Auth
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER_NAME }}
+          service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Build and push image
+        if: inputs.action == 'deploy'
+        run: |
+          IMG="${AR_LOCATION}-docker.pkg.dev/${GCP_PROJECT_ID}/${AR_REPO}/sam-one:${GITHUB_SHA}"
+          echo "IMG=${IMG}" >> "$GITHUB_ENV"
+          gcloud auth configure-docker "${AR_LOCATION}-docker.pkg.dev" --quiet
+          docker build -f Dockerfile.sam-one -t "${IMG}" .
+          docker push "${IMG}"
+
+      - name: Deploy to Cloud Run
+        if: inputs.action == 'deploy'
+        env:
+          RUNTIME_SA: ${{ vars.RUNTIME_SERVICE_ACCOUNT_EMAIL }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          # Fresh tokens every deploy; Cloud Run has no disk so they must be
+          # pinned via env vars or each instance restart regenerates them.
+          JOIN_TOKEN="sam_tok_$(openssl rand -hex 16)"
+          ADMIN_TOKEN="sam_adm_$(openssl rand -hex 16)"
+          echo "::add-mask::${JOIN_TOKEN}"
+          echo "::add-mask::${ADMIN_TOKEN}"
+          echo "JOIN_TOKEN=${JOIN_TOKEN}" >> "$GITHUB_ENV"
+          echo "ADMIN_TOKEN=${ADMIN_TOKEN}" >> "$GITHUB_ENV"
+
+          EXTRA_FLAGS=()
+          if [[ -n "${RUNTIME_SA}" ]]; then
+            EXTRA_FLAGS+=(--service-account "${RUNTIME_SA}")
+          fi
+
+          # Flag rationale: docs/user/cloud-run-deployment.md ("all load-bearing").
+          gcloud run deploy "${SERVICE}" \
+            --project "${GCP_PROJECT_ID}" --region "${REGION}" \
+            --image "${IMG}" \
+            --allow-unauthenticated \
+            --min-instances 1 --max-instances 1 \
+            --port 8080 \
+            --no-cpu-throttling \
+            --timeout 3600 \
+            --labels "managed-by=sam-one-dispatch,requested-by=$(echo "${ACTOR}" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9-_' | cut -c1-63)" \
+            --set-env-vars "SAM_TOKEN=${JOIN_TOKEN},SAM_ADMIN_TOKEN=${ADMIN_TOKEN}" \
+            "${EXTRA_FLAGS[@]}" \
+            --quiet
+
+          # The URL only exists after the first deploy; a second revision
+          # teaches the router its public wss multiaddr.
+          URL=$(gcloud run services describe "${SERVICE}" --project "${GCP_PROJECT_ID}" \
+            --region "${REGION}" --format='value(status.url)')
+          echo "URL=${URL}" >> "$GITHUB_ENV"
+          gcloud run services update "${SERVICE}" \
+            --project "${GCP_PROJECT_ID}" --region "${REGION}" \
+            --update-env-vars "SAM_EXTERNAL_URL=${URL}" \
+            --quiet
+
+      - name: Verify readiness
+        if: inputs.action == 'deploy'
+        run: |
+          # /healthz is swallowed by the Google frontend on run.app; use /readyz.
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 10 "${URL}/readyz" >/dev/null 2>&1; then
+              echo "sam-one ready at ${URL}"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::${URL}/readyz never became ready"
+          exit 1
+
+      - name: Publish summary
+        if: inputs.action == 'deploy'
+        env:
+          ACTOR: ${{ github.actor }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq age
+
+          # Encrypt the tokens to the triggering user's GitHub SSH keys so
+          # they can be published in a public job summary.
+          curl -fsSL "https://github.com/${ACTOR}.keys" \
+            | grep -E '^(ssh-ed25519|ssh-rsa) ' > /tmp/recipient.keys || true
+
+          {
+            echo "## sam-one sandbox \`${SERVICE}\` (${REGION})"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Service URL | ${URL} |"
+            echo "| Console | ${URL}/console |"
+            echo "| Built from | \`${REF_NAME}\` @ \`${GITHUB_SHA}\` |"
+            echo
+            echo "Join a node:"
+            echo
+            echo '```bash'
+            echo "sam-node run --control-plane ${URL} --bootstrap-token <JOIN_TOKEN>"
+            echo '```'
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ -s /tmp/recipient.keys ]]; then
+            {
+              echo "### Tokens (encrypted to @${ACTOR}'s SSH keys)"
+              echo
+              echo "Decrypt with the matching private key:"
+              echo
+              echo '```bash'
+              echo "age -d -i ~/.ssh/id_ed25519 <<'EOF'"
+              printf 'JOIN_TOKEN=%s\nADMIN_TOKEN=%s\n' "${JOIN_TOKEN}" "${ADMIN_TOKEN}" \
+                | age -a -R /tmp/recipient.keys
+              echo "EOF"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "> [!WARNING]"
+              echo "> @${ACTOR} has no RSA/ed25519 SSH keys on GitHub, so the"
+              echo "> generated tokens were not published. Add a key at"
+              echo "> https://github.com/settings/keys and re-run the workflow."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Delete service
+        if: inputs.action == 'delete'
+        run: |
+          gcloud run services delete "${SERVICE}" \
+            --project "${GCP_PROJECT_ID}" --region "${REGION}" --quiet
+          echo "Deleted \`${SERVICE}\` from ${REGION}." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow to deploy (or delete) throwaway `sam-one` sandboxes on Cloud Run, so contributors can get a public mesh endpoint without GCP access.

- **Inputs:** `action` (deploy/delete), `name` (service becomes `sam-one-<name>`, validated), `region`.
- **Gate:** the `sam-one-sandbox` GitHub environment requires reviewer approval before GCP credentials are minted (WIF, no keys).
- **Outputs:** service URL, console URL and join command in the job summary; generated join/admin tokens are `::add-mask::`ed and published only age-encrypted to the triggering user's GitHub SSH keys (`github.com/<user>.keys`), so nothing secret lands in public logs.
- Follows the validated Cloud Run recipe in `site/content/docs/user/cloud-run-deployment.md`: pinned tokens via env vars, singleton instance, `--no-cpu-throttling`, `--timeout 3600`, second revision sets `SAM_EXTERNAL_URL`, readiness via `/readyz`.
- Image is built from the dispatched ref and pushed to the existing `sam-mesh` Artifact Registry repo (us-central1); Cloud Run pulls cross-region.

Infra already provisioned: `sam-one-sandbox` environment (required reviewer) with `RUNTIME_SERVICE_ACCOUNT_EMAIL`, zero-role `sam-one-runtime` SA, and `roles/run.admin` for the existing deployer SA. Reuses the repo-level `WIF_PROVIDER_NAME`/`SERVICE_ACCOUNT_EMAIL`/`GCP_PROJECT_ID` variables.