### PR TITLE
deploy: sam-one sandbox summary join command needs --bind-addr ""

### DIFF
--- a/.github/workflows/deploy-sam-one.yaml
+++ b/.github/workflows/deploy-sam-one.yaml
@@ -166,10 +166,10 @@ jobs:
             echo "| Console | ${URL}/console |"
             echo "| Built from | \`${REF_NAME}\` @ \`${GITHUB_SHA}\` |"
             echo
-            echo "Join a node:"
+            echo "Join a node (socket-only local API; or export SAM_API_TOKEN instead of --bind-addr \"\"):"
             echo
             echo '```bash'
-            echo "sam-node run --control-plane ${URL} --bootstrap-token <JOIN_TOKEN>"
+            echo "sam-node run --control-plane ${URL} --bootstrap-token <JOIN_TOKEN> --bind-addr \"\""
             echo '```'
             echo
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The join command printed in the sandbox job summary fataled on a fresh machine: `sam-node`'s local API defaults to TCP `127.0.0.1:8080`, which refuses to start without `SAM_API_TOKEN`/mTLS. `--bind-addr ""` serves the local API only on the Unix socket, where owner-only permissions replace the token. The summary line now also points at the `SAM_API_TOKEN` alternative.