### PR TITLE
prevent concurrent close panics in channelListener

### DIFF
--- a/internal/sambox/gateway.go
+++ b/internal/sambox/gateway.go
@@ -483,6 +483,7 @@ func (c *bufferedConn) Read(b []byte) (int, error) {
 type channelListener struct {
 	conns  chan net.Conn
 	closed chan struct{}
+	once   sync.Once
 }
 
 func (l *channelListener) Accept() (net.Conn, error) {
@@ -495,11 +496,17 @@ func (l *channelListener) Accept() (net.Conn, error) {
 }
 
 func (l *channelListener) Close() error {
-	select {
-	case <-l.closed:
-	default:
+	l.once.Do(func() {
 		close(l.closed)
-	}
+		for {
+			select {
+			case conn := <-l.conns:
+				_ = conn.Close()
+			default:
+				return
+			}
+		}
+	})
 	return nil
 }
 


### PR DESCRIPTION
The channelListener.Close() method in internal/sambox/gateway.go contains a race condition. If multiple goroutines attempt to close the listener concurrently during disconnections a panic occurs for closing a closed channel, which crashes the node

This patch replaces the unsafe select block with sync.Once to guarantee the channel closes exactly once and avoids the panic completely